### PR TITLE
giAdd "vectorized" option to sklearn explain_prediction

### DIFF
--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -39,11 +39,14 @@ def explain_prediction(clf, vec, doc, top=_TOP, class_names=None,
 @explain_prediction.register(Perceptron)
 @explain_prediction.register(LinearSVC)
 def explain_prediction_linear(clf, vec, doc, top=_TOP, class_names=None,
-                              feature_names=None):
+                              feature_names=None, vectorized=False):
     """ Explain prediction of a linear classifier. """
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
 
-    X = vec.transform([doc]).toarray()
+    X = vec.transform([doc]) if not vectorized else doc
+    if sp.issparse(X):
+        X = X.toarray()
+
     if is_probabilistic_classifier(clf):
         proba = clf.predict_proba(X)[0]
     else:

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -72,6 +72,11 @@ def test_explain_linear_binary(newsgroups_train_binary):
     assert 'comp.graphics' in expl
     assert 'freedom' in expl
 
+    res_vectorized = explain_prediction(
+        clf, vec, vec.transform([docs[0]]), class_names=class_names, top=20,
+        vectorized=True)
+    assert res_vectorized == res
+
 
 def test_unsupported():
     vec = CountVectorizer()


### PR DESCRIPTION
In some cases the documents are stored already vectorized, so it's more convenient to pass them as-is.