### PR TITLE
Explaining weights for linear regression models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,14 @@ classifiers and explain their predictions.
 
 It can explain weights and predictions of:
 
-* scikit-learn linear classifiers;
-* scikit-learn decision trees and tree-based ensemble classifiers;
+* scikit-learn linear classifiers (weights and predictions) and regressors (only weights);
+* scikit-learn decision trees and tree-based ensemble classifiers (only weights);
 * any black-box classifier using LIME ( http://arxiv.org/abs/1602.04938 )
   algorithm.
 
 TODO:
 
+* explain predictions of linear regressors, decision trees and treee-based ensembles
 * https://github.com/TeamHG-Memex/sklearn-crfsuite
   and https://github.com/tpeng/python-crfsuite
 * https://github.com/scikit-learn-contrib/polylearn
@@ -44,7 +45,6 @@ TODO:
   (see https://github.com/scikit-learn/scikit-learn/issues/2237)
 * eli5.lime improvements;
 * IPython and HTML support;
-* regression models;
 * Reinforcement Learning support.
 
 License is MIT.

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -25,10 +25,10 @@ _TOP = 20
 @singledispatch
 def explain_prediction(clf, vec, doc, top=_TOP, class_names=None,
                        feature_names=None, vectorized=False):
-    """ Return an explanation of a classifier """
+    """ Return an explanation of an estimator """
     return {
-        "classifier": repr(clf),
-        "description": "Error: classifier %r is not supported" % clf,
+        "estimator": repr(clf),
+        "description": "Error: estimator %r is not supported" % clf,
     }
 
 
@@ -61,7 +61,7 @@ def explain_prediction_linear(clf, vec, doc, top=_TOP, class_names=None,
     x = X[0]
 
     res = {
-        "classifier": repr(clf),
+        "estimator": repr(clf),
         "method": "linear model",
         "classes": [],
     }

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -28,7 +28,7 @@ def explain_prediction(clf, vec, doc, top=_TOP, class_names=None,
     """ Return an explanation of a classifier """
     return {
         "classifier": repr(clf),
-        "description": "Error: classifier is not supported",
+        "description": "Error: classifier %r is not supported" % clf,
     }
 
 

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -256,7 +256,7 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None, top=_TOP
             "description": "<human readable description>",
             "targets": [
                 {
-                    "targets <target name>,
+                    "target": "<target name>",
                     "feature_weights": [
                         {
                             # positive weights

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -79,10 +79,10 @@ _TOP = 20
 @singledispatch
 def explain_weights(clf, vec=None, top=_TOP, class_names=None,
                     feature_names=None):
-    """ Return an explanation of a classifier """
+    """ Return an explanation of an estimator """
     return {
-        "classifier": repr(clf),
-        "description": "Error: classifier %r is not supported" % clf,
+        "estimator": repr(clf),
+        "description": "Error: estimator %r is not supported" % clf,
     }
 
 
@@ -99,7 +99,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
     format::
 
         {
-            "classifier": "<classifier repr>",
+            "estimator": "<classifier repr>",
             "method": "<interpretation method>",
             "description": "<human readable description>",
             "classes": [
@@ -155,7 +155,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
                 for label_id, label in enumerate(clf.classes_)
             ],
             'description': DESCRIPTION_CLF_MULTICLASS,
-            'classifier': repr(clf),
+            'estimator': repr(clf),
             'method': 'linear model',
         }
     else:
@@ -167,7 +167,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
                 'feature_weights': _features(0),
             }],
             'description': DESCRIPTION_CLF_BINARY,
-            'classifier': repr(clf),
+            'estimator': repr(clf),
             'method': 'linear model',
         }
 
@@ -183,7 +183,7 @@ def explain_rf_feature_importance(clf, vec, top=_TOP, class_names=None,
     following format::
 
         {
-            "classifier": "<classifier repr>",
+            "estimator": "<classifier repr>",
             "method": "<interpretation method>",
             "description": "<human readable description>",
             "feature_importances": [
@@ -202,7 +202,7 @@ def explain_rf_feature_importance(clf, vec, top=_TOP, class_names=None,
     return {
         'feature_importances': list(zip(names, values, std)),
         'description': DESCRIPTION_RANDOM_FOREST,
-        'classifier': repr(clf),
+        'estimator': repr(clf),
         'method': 'feature importances',
     }
 
@@ -217,7 +217,7 @@ def explain_tree_feature_importance(clf, vec=None, top=_TOP, class_names=None,
     following format (compatible with random forest explanations)::
 
         {
-            "classifier": "<classifier repr>",
+            "estimator": "<classifier repr>",
             "method": "<interpretation method>",
             "description": "<human readable description>",
             "feature_importances": [
@@ -235,7 +235,7 @@ def explain_tree_feature_importance(clf, vec=None, top=_TOP, class_names=None,
     return {
         'feature_importances': list(zip(names, values, std)),
         'description': DESCRIPTION_DECISION_TREE,
-        'classifier': repr(clf),
+        'estimator': repr(clf),
         'method': 'feature importances',
     }
 
@@ -251,7 +251,7 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None, top=_TOP
     format::
 
         {
-            "classifier": "<classifier repr>",
+            "estimator": "<regressor repr>",
             "method": "<interpretation method>",
             "description": "<human readable description>",
             "targets": [
@@ -309,7 +309,7 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None, top=_TOP
                 for target_id, target in enumerate(target_names)
                 ],
             'description': DESCRIPTION_REGRESSION_MULTITARGET,
-            'classifier': repr(clf),
+            'estimator': repr(clf),
             'method': 'linear model',
         }
     else:
@@ -319,6 +319,6 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None, top=_TOP
                 'feature_weights': _features(0),
             }],
             'description': DESCRIPTION_REGRESSION,
-            'classifier': repr(clf),
+            'estimator': repr(clf),
             'method': 'linear model',
         }

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -50,6 +50,19 @@ def get_feature_names(clf, vec=None, bias_name='<BIAS>', feature_names=None):
     return np.array(feature_names)
 
 
+def get_target_names(clf):
+    """
+    Return a vector of target names: y if the is only one target,
+    and y0, ... if there are multiple targets.
+    """
+    if len(clf.coef_.shape) == 1:
+        target_names = ['y']
+    else:
+        num_targets, _ = clf.coef_.shape
+        target_names = ['y%d' % i for i in range(num_targets)]
+    return np.array(target_names)
+
+
 def get_coef(clf, label_id):
     """
     Return a vector of coefficients for a given label,
@@ -63,7 +76,10 @@ def get_coef(clf, label_id):
         raise ValueError('Unexpected clf.coef_ shape: %s' % clf.coef_.shape)
     if not has_intercept(clf):
         return coef
-    bias = clf.intercept_[label_id]
+    if label_id == 0 and not isinstance(clf.intercept_, np.ndarray):
+        bias = clf.intercept_
+    else:
+        bias = clf.intercept_[label_id]
     return np.hstack([coef, bias])
 
 

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -69,8 +69,13 @@ def get_coef(clf, label_id):
     including bias feature.
     """
     if len(clf.coef_.shape) == 2:
-        coef = clf.coef_[label_id]  # multiclass case, also works for binary
+        # Most classifiers (even in binary case) and regressors
+        coef = clf.coef_[label_id]
     elif len(clf.coef_.shape) == 1:
+        # SGDRegressor stores coefficients in a 1D array
+        if label_id != 0:
+            raise ValueError(
+                'Unexpected label_id %s for 1D coefficient' % label_id)
         coef = clf.coef_
     else:
         raise ValueError('Unexpected clf.coef_ shape: %s' % clf.coef_.shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 import pytest
-from sklearn.datasets import fetch_20newsgroups
+import numpy as np
+from sklearn.datasets import fetch_20newsgroups, load_boston
+from sklearn.utils import shuffle
 
-CATEGORIES = [
+NEWSGROUPS_CATEGORIES = [
     'alt.atheism',
     'talk.religion.misc',
     'comp.graphics',
     'sci.space',
 ]
-CATEGORIES_BINARY = [
+NEWSGROUPS_CATEGORIES_BINARY = [
     'alt.atheism',
     'comp.graphics',
 ]
@@ -17,7 +19,8 @@ SIZE = 100
 
 def _get_newsgroups(binary=False, remove_chrome=False, test=False, size=SIZE):
     remove = ('headers', 'footers', 'quotes') if remove_chrome else []
-    categories = CATEGORIES_BINARY if binary else CATEGORIES
+    categories = (
+        NEWSGROUPS_CATEGORIES_BINARY if binary else NEWSGROUPS_CATEGORIES)
     subset = 'test' if test else 'train'
     data = fetch_20newsgroups(subset=subset, categories=categories,
                               shuffle=True, random_state=42,
@@ -33,3 +36,11 @@ def newsgroups_train():
 @pytest.fixture(scope="session")
 def newsgroups_train_binary():
     return _get_newsgroups(binary=True, remove_chrome=True)
+
+
+@pytest.fixture(scope="session")
+def boston_train(size=SIZE):
+    data = load_boston()
+    X, y = shuffle(data.data, data.target, random_state=13)
+    X = X.astype(np.float32)
+    return X[:size], y[:size], data.feature_names

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -8,6 +8,7 @@ from sklearn.linear_model import LogisticRegression, ElasticNet, SGDRegressor
 
 from eli5.sklearn.utils import (
     get_feature_names,
+    get_target_names,
     has_intercept,
     is_multiclass_classifier,
     is_multitarget_regressor,
@@ -85,3 +86,15 @@ def test_get_feature_names_1dim_coef():
     X, y = make_regression(n_targets=1, n_features=3)
     clf.fit(X, y)
     assert set(get_feature_names(clf)) == {'x0', 'x1', 'x2'}
+
+
+def test_get_target_names():
+    clf = SGDRegressor()
+    X, y = make_regression(n_targets=1, n_features=3)
+    clf.fit(X, y)
+    assert set(get_target_names(clf)) == {'y'}
+
+    clf = ElasticNet()
+    X, y = make_regression(n_targets=2, n_features=3)
+    clf.fit(X, y)
+    assert set(get_target_names(clf)) == {'y0', 'y1'}

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -51,14 +51,18 @@ def test_get_feature_names():
         assert set(get_feature_names(clf, vec)) == {'hello', 'world', '<BIAS>'}
         assert set(get_feature_names(clf, vec, 'B')) == {'hello', 'world', 'B'}
         assert set(get_feature_names(clf)) == {'x0', 'x1', '<BIAS>'}
-        assert set(get_feature_names(clf, feature_names=['a', 'b', 'c'])) == {'a', 'b', 'c'}
+        assert set(get_feature_names(clf, feature_names=['a', 'b'])) == {'a', 'b', '<BIAS>'}
+        assert set(get_feature_names(clf, feature_names=['a', 'b'],
+                                     bias_name='bias')) == {'a', 'b', 'bias'}
 
         with pytest.raises(ValueError):
-            get_feature_names(clf, feature_names=['a', 'b'])
+            get_feature_names(clf, feature_names=['a'])
 
         with pytest.raises(ValueError):
-            get_feature_names(clf, feature_names=['a', 'b', 'c', 'd'])
+            get_feature_names(clf, feature_names=['a', 'b', 'c'])
 
         clf2 = LogisticRegression(fit_intercept=False)
         clf2.fit(X, y)
         assert set(get_feature_names(clf2, vec)) == {'hello', 'world'}
+        assert set(get_feature_names(
+            clf2, feature_names=['hello', 'world'])) == {'hello', 'world'}

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -2,15 +2,15 @@
 from __future__ import absolute_import
 
 import pytest
-from sklearn.datasets import make_classification
+from sklearn.datasets import make_classification, make_regression
 from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression, ElasticNet, SGDRegressor
 
 from eli5.sklearn.utils import (
     get_feature_names,
-    get_coef,
     has_intercept,
-    is_multiclass_classifier
+    is_multiclass_classifier,
+    is_multitarget_regressor,
 )
 
 
@@ -36,6 +36,18 @@ def test_is_multiclass():
     clf2 = LogisticRegression()
     clf2.fit(X, y)
     assert is_multiclass_classifier(clf2)
+
+
+def test_is_multitarget_regressor():
+    X, y = make_regression(n_targets=1)
+    clf = ElasticNet()
+    clf.fit(X, y)
+    assert not is_multitarget_regressor(clf)
+
+    X, y = make_regression(n_targets=2)
+    clf = ElasticNet()
+    clf.fit(X, y)
+    assert is_multitarget_regressor(clf)
 
 
 def test_get_feature_names():
@@ -66,3 +78,10 @@ def test_get_feature_names():
         assert set(get_feature_names(clf2, vec)) == {'hello', 'world'}
         assert set(get_feature_names(
             clf2, feature_names=['hello', 'world'])) == {'hello', 'world'}
+
+
+def test_get_feature_names_1dim_coef():
+    clf = SGDRegressor(fit_intercept=False)
+    X, y = make_regression(n_targets=1, n_features=3)
+    clf.fit(X, y)
+    assert set(get_feature_names(clf)) == {'x0', 'x1', 'x2'}


### PR DESCRIPTION
The "classifier" key is still used in `explain_weights` result even for regression models. Not sure if we need a better name - maybe "model" is more general?