### PR TITLE
Vec not required for explain prediction

### DIFF
--- a/eli5/lime/lime.py
+++ b/eli5/lime/lime.py
@@ -112,7 +112,7 @@ def get_local_classifier_text(text, predict_proba, n_samples=1000,
                               expand_factor=10):
     """
     Train a classifier which approximates probabilistic text classifier locally.
-    Return (vec, clf, score) tuple with "easy" vectorizer, "easy" classifier,
+    Return (clf, vec, score) tuple with "easy" classifier, "easy" vectorizer,
     and an estimated accuracy score of this pipeline, i.e.
     how well these "easy" vectorizer/classifier approximates text
     classifier in neighbourhood of ``text``.

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -23,8 +23,8 @@ _TOP = 20
 
 
 @singledispatch
-def explain_prediction(clf, doc, vec=None, top=_TOP, class_names=None,
-                       feature_names=None, target_names=None):
+def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
+                       feature_names=None):
     """ Return an explanation of an estimator """
     return {
         "estimator": repr(clf),
@@ -39,7 +39,7 @@ def explain_prediction(clf, doc, vec=None, top=_TOP, class_names=None,
 @explain_prediction.register(Perceptron)
 @explain_prediction.register(LinearSVC)
 def explain_prediction_linear(
-        clf, doc, vec=None, top=_TOP, class_names=None,
+        clf, doc, vec=None, top=_TOP, target_names=None,
         feature_names=None, vectorized=False):
     """ Explain prediction of a linear classifier. """
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
@@ -67,7 +67,7 @@ def explain_prediction_linear(
         return get_top_features_dict(feature_names, scores, top)
 
     def _label(label_id, label):
-        return rename_label(label_id, label, class_names)
+        return rename_label(label_id, label, target_names)
 
     if is_multiclass_classifier(clf):
         for label_id, label in enumerate(clf.classes_):

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -24,7 +24,7 @@ _TOP = 20
 
 @singledispatch
 def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
-                       feature_names=None):
+                       feature_names=None, vectorized=False):
     """ Return an explanation of an estimator """
     return {
         "estimator": repr(clf),

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -109,8 +109,6 @@ def _add_intercept(X):
 
 
 def _get_X(doc, vec=None, vectorized=False):
-    if vec is None and not vectorized:
-        raise ValueError('vec is required when vectorized is False')
     if vec is None or vectorized:
         X = np.array([doc]) if isinstance(doc, np.ndarray) else doc
     else:

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -77,7 +77,7 @@ _TOP = 20
 
 
 @singledispatch
-def explain_weights(clf, vec=None, top=_TOP, class_names=None,
+def explain_weights(clf, vec=None, top=_TOP, target_names=None,
                     feature_names=None):
     """ Return an explanation of an estimator """
     return {
@@ -92,7 +92,7 @@ def explain_weights(clf, vec=None, top=_TOP, class_names=None,
 @explain_weights.register(PassiveAggressiveClassifier)
 @explain_weights.register(Perceptron)
 @explain_weights.register(LinearSVC)
-def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
+def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None,
                                       feature_names=None):
     """
     Return an explanation of a linear classifier weights in the following
@@ -143,7 +143,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
         return get_top_features_dict(feature_names, coef, top)
 
     def _label(label_id, label):
-        return rename_label(label_id, label, class_names)
+        return rename_label(label_id, label, target_names)
 
     if is_multiclass_classifier(clf):
         return {
@@ -176,7 +176,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, class_names=None,
 @explain_weights.register(ExtraTreesClassifier)
 @explain_weights.register(GradientBoostingClassifier)
 @explain_weights.register(AdaBoostClassifier)
-def explain_rf_feature_importance(clf, vec, top=_TOP, class_names=None,
+def explain_rf_feature_importance(clf, vec, top=_TOP, target_names=None,
                                   feature_names=None):
     """
     Return an explanation of a tree-based ensemble classifier in the
@@ -208,7 +208,7 @@ def explain_rf_feature_importance(clf, vec, top=_TOP, class_names=None,
 
 
 @explain_weights.register(DecisionTreeClassifier)
-def explain_tree_feature_importance(clf, vec=None, top=_TOP, class_names=None,
+def explain_tree_feature_importance(clf, vec=None, top=_TOP, target_names=None,
                                     feature_names=None):
     """
     TODO/FIXME: should it be a tree instead?

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -35,7 +35,7 @@ def get_feature_names(clf, vec=None, bias_name='<BIAS>', feature_names=None):
     """
     if feature_names is None:
         if vec and hasattr(vec, 'get_feature_names'):
-            feature_names = vec.get_feature_names()
+            feature_names = list(vec.get_feature_names())
         else:
             num_features = clf.coef_.shape[-1]
             feature_names = ["x%d" % i for i in range(num_features)]

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -88,10 +88,10 @@ def get_coef(clf, label_id):
     return np.hstack([coef, bias])
 
 
-def rename_label(label_id, label, class_names):
-    """ Rename label according to class_names """
-    if class_names is None:
+def rename_label(label_id, label, target_names):
+    """ Rename label according to target_names """
+    if target_names is None:
         return label
-    if isinstance(class_names, dict):
-        return class_names[label]
-    return class_names[label_id]
+    if isinstance(target_names, dict):
+        return target_names[label]
+    return target_names[label_id]

--- a/tests/test_lime.py
+++ b/tests/test_lime.py
@@ -28,7 +28,7 @@ def test_lime_explain_probabilistic(newsgroups_train):
     print(score)
     assert score > 0.7
 
-    res = explain_prediction(clf_local, vec_local, doc, top=10,
+    res = explain_prediction(clf_local, doc, vec_local, top=10,
                              class_names=class_names)
     expl = format_as_text(res)
     print(expl)

--- a/tests/test_lime.py
+++ b/tests/test_lime.py
@@ -11,7 +11,7 @@ from sklearn.pipeline import make_pipeline
 
 
 def test_lime_explain_probabilistic(newsgroups_train):
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = HashingVectorizer(non_negative=True)
     clf = MultinomialNB()
 
@@ -29,7 +29,7 @@ def test_lime_explain_probabilistic(newsgroups_train):
     assert score > 0.7
 
     res = explain_prediction(clf_local, doc, vec_local, top=10,
-                             class_names=class_names)
+                             target_names=target_names)
     expl = format_as_text(res)
     print(expl)
     assert 'file' in expl

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 from pprint import pprint
 
-import numpy as np
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.feature_extraction.dict_vectorizer import DictVectorizer
 from sklearn.linear_model import (
@@ -109,12 +108,3 @@ def test_unsupported():
     clf = BaseEstimator()
     res = explain_prediction(clf, 'hello, world', vec)
     assert 'Error' in res['description']
-
-
-def test_without_vec():
-    clf = LogisticRegression()
-    clf.fit(np.array([[1], [0]]), np.array([0, 1]))
-    with pytest.raises(ValueError) as excinfo:
-        explain_prediction(clf, 'hello, world')
-    assert 'vec' in str(excinfo.value)
-    assert 'vectorized' in str(excinfo.value)

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -31,13 +31,13 @@ from eli5.formatters import format_as_text
     [LinearSVC()],
 ])
 def test_explain_linear(newsgroups_train, clf):
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = TfidfVectorizer()
 
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_prediction(clf, docs[0], vec=vec, class_names=class_names, top=20)
+    res = explain_prediction(clf, docs[0], vec=vec, target_names=target_names, top=20)
     expl = format_as_text(res)
     print(expl)
     pprint(res)
@@ -48,19 +48,19 @@ def test_explain_linear(newsgroups_train, clf):
         pos = {name for name, value in e['feature_weights']['pos']}
         assert 'file' in pos
 
-    for label in class_names:
+    for label in target_names:
         assert str(label) in expl
     assert 'file' in expl
 
 
 def test_explain_linear_binary(newsgroups_train_binary):
-    docs, y, class_names = newsgroups_train_binary
+    docs, y, target_names = newsgroups_train_binary
     vec = TfidfVectorizer()
     clf = LogisticRegression()
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_prediction(clf, docs[0], vec, class_names=class_names, top=20)
+    res = explain_prediction(clf, docs[0], vec, target_names=target_names, top=20)
     expl = format_as_text(res)
     print(expl)
     pprint(res)
@@ -74,7 +74,7 @@ def test_explain_linear_binary(newsgroups_train_binary):
     assert 'freedom' in expl
 
     res_vectorized = explain_prediction(
-        clf, vec.transform([docs[0]])[0], vec, class_names=class_names,
+        clf, vec.transform([docs[0]])[0], vec, target_names=target_names,
         top=20, vectorized=True)
     assert res_vectorized == res
 
@@ -89,14 +89,14 @@ def test_explain_linear_dense():
     X = vec.fit_transform(data)
     clf.fit(X, [0, 1, 1, 0])
     test_day = {'day': 'tue', 'moon': 'full'}
-    class_names = ['sunny', 'shady']
-    res1 = explain_prediction(clf, test_day, vec, class_names=class_names)
+    target_names = ['sunny', 'shady']
+    res1 = explain_prediction(clf, test_day, vec, target_names=target_names)
     expl1 = format_as_text(res1)
     print(expl1)
     assert 'day=tue' in expl1
     [test_day_vec] = vec.transform(test_day)
     res2 = explain_prediction(
-        clf, test_day_vec, class_names=class_names,
+        clf, test_day_vec, target_names=target_names,
         vectorized=True, feature_names=vec.get_feature_names())
     expl2 = format_as_text(res1)
     print(expl2)

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -150,11 +150,11 @@ def test_unsupported():
 
 
 @pytest.mark.parametrize(['clf'], [
-    [ElasticNet()],
+    [ElasticNet(random_state=42)],
     [Lars()],
-    [Lasso()],
-    [Ridge()],
-    [SGDRegressor()],
+    [Lasso(random_state=42)],
+    [Ridge(random_state=42)],
+    [SGDRegressor(random_state=42)],
 ])
 def test_explain_linear_regression(boston_train, clf):
     X, y, feature_names = boston_train
@@ -174,10 +174,10 @@ def test_explain_linear_regression(boston_train, clf):
 
 
 @pytest.mark.parametrize(['clf'], [
-    [ElasticNet()],
+    [ElasticNet(random_state=42)],
     [Lars()],
-    [Lasso()],
-    [Ridge()],
+    [Lasso(random_state=42)],
+    [Ridge(random_state=42)],
 ])
 def test_explain_linear_regression_multitarget(clf):
     X, y = make_regression(n_samples=100, n_targets=3, n_features=10)

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -43,17 +43,17 @@ from eli5.formatters import format_as_text
     [LinearSVC()],
 ])
 def test_explain_linear(newsgroups_train, clf):
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = TfidfVectorizer()
 
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_weights(clf, vec, class_names=class_names, top=20)
+    res = explain_weights(clf, vec, target_names=target_names, top=20)
     expl = format_as_text(res)
     print(expl)
 
-    assert [cl['class'] for cl in res['classes']] == class_names
+    assert [cl['class'] for cl in res['classes']] == target_names
 
     _top = partial(top_pos_neg, res['classes'], 'class')
     pos, neg = _top('sci.space')
@@ -67,7 +67,7 @@ def test_explain_linear(newsgroups_train, clf):
 
     assert 'space' in expl
     assert 'atheists' in expl
-    for label in class_names:
+    for label in target_names:
         assert str(label) in expl
 
 
@@ -81,14 +81,14 @@ def top_pos_neg(classes, key, class_name):
 
 
 def test_explain_linear_tuple_top(newsgroups_train):
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = TfidfVectorizer()
     clf = LogisticRegression()
 
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res_neg = explain_weights(clf, vec, class_names=class_names, top=(0, 10))
+    res_neg = explain_weights(clf, vec, target_names=target_names, top=(0, 10))
     expl_neg = format_as_text(res_neg)
     print(expl_neg)
 
@@ -98,7 +98,7 @@ def test_explain_linear_tuple_top(newsgroups_train):
 
     assert "+0." not in expl_neg
 
-    res_pos = explain_weights(clf, vec, class_names=class_names, top=(10, 2))
+    res_pos = explain_weights(clf, vec, target_names=target_names, top=(10, 2))
     expl_pos = format_as_text(res_pos)
     print(expl_pos)
 
@@ -115,12 +115,12 @@ def test_explain_linear_tuple_top(newsgroups_train):
     [DecisionTreeClassifier()],
 ])
 def test_explain_random_forest(newsgroups_train, clf):
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = TfidfVectorizer()
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
 
-    res = explain_weights(clf, vec, class_names=class_names, top=30)
+    res = explain_weights(clf, vec, target_names=target_names, top=30)
     expl = format_as_text(res)
     print(expl)
     assert 'feature importances' in expl
@@ -129,17 +129,17 @@ def test_explain_random_forest(newsgroups_train, clf):
 
 def test_explain_empty(newsgroups_train):
     clf = LogisticRegression(C=0.01, penalty='l1')
-    docs, y, class_names = newsgroups_train
+    docs, y, target_names = newsgroups_train
     vec = TfidfVectorizer()
 
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_weights(clf, vec, class_names=class_names, top=20)
+    res = explain_weights(clf, vec, target_names=target_names, top=20)
     expl = format_as_text(res)
     print(expl)
 
-    assert [cl['class'] for cl in res['classes']] == class_names
+    assert [cl['class'] for cl in res['classes']] == target_names
 
 
 def test_unsupported():


### PR DESCRIPTION
Not that I hate vectorizers :)
But ``vec`` is not strictly required for ``explain_prediction`` (in the same way it is not required for explain_weights), so I think it makes sense to have ``vec`` after ``doc``. I'm not 100% sure about 8bcb706 though - with it we need to pass vectorized=True only if we pass vec and already vectorized doc, but don't have to do it if we don't pass vec - not sure if it's too magical.