### PR TITLE
Explain hashing vectorizer

### DIFF
--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -3,6 +3,7 @@ from singledispatch import singledispatch
 
 import numpy as np
 import scipy.sparse as sp
+from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.linear_model import (
     ElasticNet,
     Lars,
@@ -17,6 +18,7 @@ from sklearn.linear_model import (
 )
 from sklearn.svm import LinearSVC, LinearSVR
 
+from eli5.sklearn.unhashing import InvertableHashingVectorizer, handle_hashing_vec
 from eli5.sklearn.utils import (
     get_feature_names,
     get_coef,
@@ -51,8 +53,13 @@ def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
 @explain_prediction.register(LinearSVC)
 def explain_prediction_linear_classifier(
         clf, doc, vec=None, top=_TOP, target_names=None,
-        feature_names=None, vectorized=False):
+        feature_names=None, vectorized=False, coef_scale=None):
     """ Explain prediction of a linear classifier. """
+    if isinstance(vec, HashingVectorizer) and not vectorized:
+        vec = InvertableHashingVectorizer(vec)
+        vec.fit([doc])
+    feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
+                                                   coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     X = _get_X(doc, vec=vec, vectorized=vectorized)
 
@@ -73,7 +80,7 @@ def explain_prediction_linear_classifier(
     }
 
     def _weights(label_id):
-        coef = get_coef(clf, label_id)
+        coef = get_coef(clf, label_id, scale=coef_scale)
         scores = _multiply(x, coef)
         return get_top_features_dict(feature_names, scores, top)
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -37,7 +37,7 @@ _TOP = 20
 
 @singledispatch
 def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
-                       feature_names=None, vectorized=False):
+                       feature_names=None, vectorized=False, coef_scale=None):
     """ Return an explanation of an estimator """
     return {
         "estimator": repr(clf),

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -28,7 +28,7 @@ from sklearn.tree import DecisionTreeClassifier
 
 from eli5._feature_weights import get_top_features_dict
 from eli5.utils import argsort_k_largest
-from eli5.sklearn.unhashing import InvertableHashingVectorizer
+from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing
 from eli5.sklearn.utils import (
     get_coef,
     is_multiclass_classifier,
@@ -148,10 +148,10 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
 
     To print it use utilities from eli5.formatters.
     """
-    feature_names, coef_scale = _handle_hashing_vec(vec, feature_names,
+    feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
                                                     coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
-    _extra_caveats = "\n" + HASHING_CAVEATS if _is_invhashing(vec) else ''
+    _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 
     def _features(label_id):
         coef = get_coef(clf, label_id, scale=coef_scale)
@@ -306,10 +306,10 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None,
 
     To print it use utilities from eli5.formatters.
     """
-    feature_names, coef_scale = _handle_hashing_vec(vec, feature_names,
+    feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
                                                     coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
-    _extra_caveats = "\n" + HASHING_CAVEATS if _is_invhashing(vec) else ''
+    _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 
     def _features(target_id):
         coef = get_coef(clf, target_id, scale=coef_scale)
@@ -343,16 +343,3 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None,
             'estimator': repr(clf),
             'method': 'linear model',
         }
-
-
-def _handle_hashing_vec(vec, feature_names, coef_scale):
-    if _is_invhashing(vec):
-        if feature_names is None:
-            feature_names = vec.get_feature_names(always_signed=False)
-        if coef_scale is None:
-            coef_scale = vec.column_signs_
-    return feature_names, coef_scale
-
-
-def _is_invhashing(vec):
-    return isinstance(vec, InvertableHashingVectorizer)

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -149,7 +149,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
     To print it use utilities from eli5.formatters.
     """
     feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
-                                                    coef_scale)
+                                                   coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 

--- a/eli5/sklearn/unhashing.py
+++ b/eli5/sklearn/unhashing.py
@@ -230,3 +230,16 @@ def _format_name(names, signs, sep=" | ", always_signed=False):
     if not always_signed and len(set(signs)) == 1:
         return sep.join(names)
     return sep.join(_signed(n, s) for n, s in zip(names, signs))
+
+
+def handle_hashing_vec(vec, feature_names, coef_scale):
+    if is_invhashing(vec):
+        if feature_names is None:
+            feature_names = vec.get_feature_names(always_signed=False)
+        if coef_scale is None:
+            coef_scale = vec.column_signs_
+    return feature_names, coef_scale
+
+
+def is_invhashing(vec):
+    return isinstance(vec, InvertableHashingVectorizer)

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -91,6 +91,7 @@ def get_coef(clf, label_id, scale=None):
             ))
         # print("shape is ok")
         not_nan = ~np.isnan(scale)
+        coef = coef.copy()
         coef[not_nan] *= scale[not_nan]
 
     if not has_intercept(clf):

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -45,7 +45,9 @@ def test_explain_linear(newsgroups_train, clf):
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_prediction(clf, docs[0], vec=vec, target_names=target_names, top=20)
+    get_res = lambda: explain_prediction(
+        clf, docs[0], vec=vec, target_names=target_names, top=20)
+    res = get_res()
     expl = format_as_text(res)
     print(expl)
     pprint(res)
@@ -59,6 +61,8 @@ def test_explain_linear(newsgroups_train, clf):
     for label in target_names:
         assert str(label) in expl
     assert 'file' in expl
+
+    assert res == get_res()
 
 
 def check_explain_linear_binary(res):
@@ -84,9 +88,11 @@ def test_explain_linear_binary(vec, newsgroups_train_binary):
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_prediction(
+    get_res = lambda: explain_prediction(
         clf, docs[0], vec, target_names=target_names, top=20)
+    res = get_res()
     check_explain_linear_binary(res)
+    assert res == get_res()
     res_vectorized = explain_prediction(
         clf, vec.transform([docs[0]])[0], vec, target_names=target_names,
         top=20, vectorized=True)
@@ -109,9 +115,11 @@ def test_explain_hashing_vectorizer(newsgroups_train_binary):
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    res = explain_prediction(
+    get_res = lambda: explain_prediction(
         clf, docs[0], ivec, target_names=target_names, top=20)
+    res = get_res()
     check_explain_linear_binary(res)
+    assert res == get_res()
     res_vectorized = explain_prediction(
         clf, vec.transform([docs[0]])[0], ivec, target_names=target_names,
         top=20, vectorized=True)
@@ -179,6 +187,8 @@ def test_explain_linear_regression(boston_train, clf):
     assert '<BIAS>' in expl
     assert "'y'" in expl
 
+    assert res == explain_prediction(clf, X[0])
+
 
 @pytest.mark.parametrize(['clf'], [
     [ElasticNet(random_state=42)],
@@ -207,3 +217,5 @@ def test_explain_linear_regression_multitarget(clf):
     assert 'x8' in expl
     assert '<BIAS>' in expl
     assert "'y2'" in expl
+
+    assert res == explain_prediction(clf, X[0])

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -115,8 +115,8 @@ def test_explain_hashing_vectorizer(newsgroups_train_binary):
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    get_res = lambda: explain_prediction(
-        clf, docs[0], ivec, target_names=target_names, top=20)
+    get_res = lambda **kwargs: explain_prediction(
+        clf, docs[0], ivec, target_names=target_names, top=20, **kwargs)
     res = get_res()
     check_explain_linear_binary(res)
     assert res == get_res()
@@ -125,6 +125,10 @@ def test_explain_hashing_vectorizer(newsgroups_train_binary):
         top=20, vectorized=True)
     pprint(res_vectorized)
     assert res_vectorized == res
+
+    assert res == get_res(
+        feature_names=ivec.get_feature_names(always_signed=False),
+        coef_scale=ivec.column_signs_)
 
 
 def test_explain_linear_dense():

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -37,7 +37,9 @@ from eli5.formatters import format_as_text
 
 
 def check_newsgroups_explanation_linear(clf, vec, target_names):
-    res = explain_weights(clf, vec, target_names=target_names, top=20)
+    get_res = lambda: explain_weights(
+        clf, vec, target_names=target_names, top=20)
+    res = get_res()
     expl = format_as_text(res)
     print(expl)
 
@@ -57,6 +59,8 @@ def check_newsgroups_explanation_linear(clf, vec, target_names):
     assert 'atheists' in expl
     for label in target_names:
         assert str(label) in expl
+
+    assert res == get_res()
 
 
 @pytest.mark.parametrize(['clf'], [
@@ -149,11 +153,15 @@ def test_explain_random_forest(newsgroups_train, clf):
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
 
-    res = explain_weights(clf, vec, target_names=target_names, top=30)
+    get_res = lambda: explain_weights(
+        clf, vec, target_names=target_names, top=30)
+    res = get_res()
     expl = format_as_text(res)
     print(expl)
     assert 'feature importances' in expl
     assert 'that 0.' in expl  # high-ranked feature
+
+    assert res == get_res()
 
 
 def test_explain_empty(newsgroups_train):
@@ -203,6 +211,8 @@ def test_explain_linear_regression(boston_train, clf):
     assert 'x9' in neg or 'x9' in pos
     assert '<BIAS>' in neg or '<BIAS>' in pos
 
+    assert res == explain_weights(clf)
+
 
 @pytest.mark.parametrize(['clf'], [
     [ElasticNet(random_state=42)],
@@ -225,3 +235,5 @@ def test_explain_linear_regression_multitarget(clf):
     pos, neg = top_pos_neg(res['targets'], 'target', 'y2')
     assert 'x9' in neg or 'x9' in pos
     assert '<BIAS>' in neg or '<BIAS>' in pos
+
+    assert res == explain_weights(clf)


### PR DESCRIPTION
When the hashing vectorizer is passed as-is (not wrapped into InvertableHashingVectorizer), then an InvertableHashingVectorizer is built when explaining predictions for this document, and then discarded. If the InvertableHashingVectorizer is passed, then it is assumed that it was already fit (it's also possible to call a partial fit for it, but it seems to complicate the API).

Fixes #12