### PR TITLE
Fix unhashing explain prediction

### DIFF
--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -18,7 +18,7 @@ from sklearn.linear_model import (
 )
 from sklearn.svm import LinearSVC, LinearSVR
 
-from eli5.sklearn.unhashing import InvertableHashingVectorizer, handle_hashing_vec
+from eli5.sklearn.unhashing import InvertableHashingVectorizer, is_invhashing
 from eli5.sklearn.utils import (
     get_feature_names,
     get_coef,
@@ -37,7 +37,7 @@ _TOP = 20
 
 @singledispatch
 def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
-                       feature_names=None, vectorized=False, coef_scale=None):
+                       feature_names=None, vectorized=False):
     """ Return an explanation of an estimator """
     return {
         "estimator": repr(clf),
@@ -53,10 +53,9 @@ def explain_prediction(clf, doc, vec=None, top=_TOP, target_names=None,
 @explain_prediction.register(LinearSVC)
 def explain_prediction_linear_classifier(
         clf, doc, vec=None, top=_TOP, target_names=None,
-        feature_names=None, vectorized=False, coef_scale=None):
+        feature_names=None, vectorized=False):
     """ Explain prediction of a linear classifier. """
-    vec, feature_names, coef_scale = _handle_vec(
-        clf, doc, vec, vectorized, feature_names, coef_scale)
+    vec, feature_names = _handle_vec(clf, doc, vec, vectorized, feature_names)
     X = _get_X(doc, vec=vec, vectorized=vectorized)
 
     if is_probabilistic_classifier(clf):
@@ -76,7 +75,7 @@ def explain_prediction_linear_classifier(
     }
 
     def _weights(label_id):
-        coef = get_coef(clf, label_id, scale=coef_scale)
+        coef = get_coef(clf, label_id)
         scores = _multiply(x, coef)
         return get_top_features_dict(feature_names, scores, top)
 
@@ -131,14 +130,16 @@ def _get_X(doc, vec=None, vectorized=False):
     return X
 
 
-def _handle_vec(clf, doc, vec, vectorized, feature_names, coef_scale):
+def _handle_vec(clf, doc, vec, vectorized, feature_names):
     if isinstance(vec, HashingVectorizer) and not vectorized:
         vec = InvertableHashingVectorizer(vec)
         vec.fit([doc])
-    feature_names, coef_scale = handle_hashing_vec(
-        vec, feature_names, coef_scale)
+    if is_invhashing(vec) and feature_names is None:
+        # Explaining predictions does not need coef_scale,
+        # because it is handled by the vectorizer.
+        feature_names = vec.get_feature_names(always_signed=False)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
-    return vec, feature_names, coef_scale
+    return vec, feature_names
 
 
 @explain_prediction.register(ElasticNet)
@@ -149,10 +150,9 @@ def _handle_vec(clf, doc, vec, vectorized, feature_names, coef_scale):
 @explain_prediction.register(SGDRegressor)
 def explain_prediction_linear_regressor(
         clf, doc, vec=None, top=_TOP, target_names=None,
-        feature_names=None, vectorized=False, coef_scale=None):
+        feature_names=None, vectorized=False):
     """ Explain prediction of a linear regressor. """
-    vec, feature_names, coef_scale = _handle_vec(
-        clf, doc, vec, vectorized, feature_names, coef_scale)
+    vec, feature_names = _handle_vec(clf, doc, vec, vectorized, feature_names)
     X = _get_X(doc, vec=vec, vectorized=vectorized)
 
     score, = clf.predict(X)
@@ -168,7 +168,7 @@ def explain_prediction_linear_regressor(
     }
 
     def _weights(label_id):
-        coef = get_coef(clf, label_id, scale=coef_scale)
+        coef = get_coef(clf, label_id)
         scores = _multiply(x, coef)
         return get_top_features_dict(feature_names, scores, top)
 

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -108,6 +108,7 @@ def test_explain_linear_hashed(newsgroups_train, clf):
 def test_explain_linear_hashed_pos_neg(newsgroups_train, pass_feature_weights):
     docs, y, target_names = newsgroups_train
     # make it binary
+    y = y.copy()
     y[y != 0] = 1
     target_names = [target_names[0], 'other']
     vec = HashingVectorizer(norm=None)


### PR DESCRIPTION
It turned out that #12 was wrong, we don't need to pass coef_scale to explain_prediction (I just blindly copied it from explain_weights and realised it only now).

I added two detailed test that use ``HashingVectorizer(norm=None)`` and compare results with ``CountVectorizer()``.