### PR TITLE
Make feature_names include bias term again

### DIFF
--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -29,6 +29,7 @@ from eli5.sklearn.utils import (
     is_probabilistic_classifier,
     has_intercept,
     rename_label,
+    with_bias_name,
 )
 from eli5.sklearn.text import get_weighted_spans
 from eli5._feature_weights import get_top_features_dict
@@ -150,6 +151,8 @@ def _handle_vec(clf, doc, vec, vectorized, feature_names):
         # Explaining predictions does not need coef_scale,
         # because it is handled by the vectorizer.
         feature_names = vec.get_feature_names(always_signed=False)
+        if has_intercept(clf):
+            feature_names = with_bias_name(feature_names)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     return vec, feature_names
 

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -148,7 +148,7 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
 
     To print it use utilities from eli5.formatters.
     """
-    feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
+    feature_names, coef_scale = handle_hashing_vec(clf, vec, feature_names,
                                                    coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
@@ -306,8 +306,8 @@ def explain_linear_regressor_weights(clf, vec=None, feature_names=None,
 
     To print it use utilities from eli5.formatters.
     """
-    feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
-                                                    coef_scale)
+    feature_names, coef_scale = handle_hashing_vec(clf, vec, feature_names,
+                                                   coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 

--- a/eli5/sklearn/unhashing.py
+++ b/eli5/sklearn/unhashing.py
@@ -4,7 +4,6 @@ Utilities to reverse transformation done by FeatureHasher or HashingVectorizer.
 """
 from __future__ import absolute_import
 
-from functools import partial
 from collections import defaultdict, Counter
 from itertools import chain
 from typing import List, Iterable
@@ -12,6 +11,8 @@ from typing import List, Iterable
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_extraction.text import HashingVectorizer, FeatureHasher
+
+from .utils import has_intercept, with_bias_name
 
 
 class InvertableHashingVectorizer(BaseEstimator, TransformerMixin):
@@ -212,10 +213,12 @@ def _invert_signs(signs):
     return signs[0] < 0
 
 
-def handle_hashing_vec(vec, feature_names, coef_scale):
+def handle_hashing_vec(clf, vec, feature_names, coef_scale):
     if is_invhashing(vec):
         if feature_names is None:
             feature_names = vec.get_feature_names(always_signed=False)
+            if has_intercept(clf):
+                feature_names = with_bias_name(feature_names)
         if coef_scale is None:
             coef_scale = vec.column_signs_
     return feature_names, coef_scale

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -24,6 +24,7 @@ from sklearn.base import BaseEstimator
 import pytest
 
 from eli5.sklearn import explain_prediction, InvertableHashingVectorizer
+from eli5.sklearn.utils import with_bias_name
 from .utils import format_as_all, strip_blanks, get_all_features, get_names_coefs
 
 
@@ -124,8 +125,8 @@ def test_explain_hashing_vectorizer(newsgroups_train_binary):
     pprint(res_vectorized)
     assert res_vectorized == _without_weighted_spans(res)
 
-    assert res == get_res(
-        feature_names=ivec.get_feature_names(always_signed=False))
+    assert res == get_res(feature_names=with_bias_name(
+        ivec.get_feature_names(always_signed=False)))
 
 
 def _without_weighted_spans(res):
@@ -153,7 +154,7 @@ def test_explain_linear_dense():
     [test_day_vec] = vec.transform(test_day)
     res2 = explain_prediction(
         clf, test_day_vec, target_names=target_names,
-        vectorized=True, feature_names=vec.get_feature_names())
+        vectorized=True, feature_names=with_bias_name(vec.get_feature_names()))
     assert res1 == res2
 
 

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -33,6 +33,7 @@ from sklearn.base import BaseEstimator
 import pytest
 
 from eli5.sklearn import explain_weights, InvertableHashingVectorizer
+from eli5.sklearn.utils import with_bias_name
 from .utils import format_as_all, get_all_features, get_names_coefs
 
 
@@ -120,7 +121,7 @@ def test_explain_linear_hashed_pos_neg(newsgroups_train, pass_feature_weights):
     if pass_feature_weights:
         res = explain_weights(
             clf, top=(10, 10), target_names=target_names,
-            feature_names=ivec.get_feature_names(always_signed=False),
+            feature_names=with_bias_name(ivec.get_feature_names(always_signed=False)),
             coef_scale=ivec.column_signs_)
     else:
         res = explain_weights(

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -72,16 +72,15 @@ def test_get_feature_names():
         assert _names(clf, vec) == {'hello', 'world', '<BIAS>'}
         assert _names(clf, vec, 'B') == {'hello', 'world', 'B'}
         assert _names(clf) == {'x0', 'x1', '<BIAS>'}
-        assert _names(clf, feature_names=['a', 'b']) == {'a', 'b', '<BIAS>'}
-        assert _names(clf, feature_names=['a', 'b'],
-                                   bias_name='bias') == {'a', 'b', 'bias'}
-        assert _names(clf, feature_names=np.array(['a', 'b'])) == {'a', 'b', '<BIAS>'}
+        assert _names(clf, feature_names=['a', 'b', 'bias']) == {'a', 'b', 'bias'}
+        assert _names(clf, feature_names=np.array(['a', 'b', 'bias'])) == \
+               {'a', 'b', 'bias'}
 
         with pytest.raises(ValueError):
-            get_feature_names(clf, feature_names=['a'])
+            get_feature_names(clf, feature_names=['a', 'b'])
 
         with pytest.raises(ValueError):
-            get_feature_names(clf, feature_names=['a', 'b', 'c'])
+            get_feature_names(clf, feature_names=['a', 'b', 'c', 'd'])
 
         clf2 = LogisticRegression(fit_intercept=False)
         clf2.fit(X, y)


### PR DESCRIPTION
Sorry for changing my ming about this issue again.

Internally, we need to have the bias name in feature_names, and if we always add it to externally passed feature_names, it can be a major bottleneck. This change allows pre-computing feature_names and passing it as a numpy array.

For example, this is ``explain_prediction`` (with pre-computing ``feature_names`` included) for 650 links before http://vmprof.com/#/5b1da0f7cfa4c94cd035fe436b6024f5?id=0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0&view=flames and after http://vmprof.com/#/a126da42ad0e64372b35083c366c0855?id=0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0&view=flames this change. Adding a bias to a long list of feature names and converting it to numpy array took 2/3 of total runtime.

It's also possible to accept ``feature_names`` both with and without bias feature name, adding it if needed. It makes API easier to use, but might lead to unnoticed off-by-one errors. Not sure which way is better?