### PR TITLE
Make feature names lazy

### DIFF
--- a/eli5/sklearn/unhashing.py
+++ b/eli5/sklearn/unhashing.py
@@ -13,6 +13,8 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_extraction.text import HashingVectorizer, FeatureHasher
 
+from eli5.sklearn.utils import FeatureNames
+
 
 class InvertableHashingVectorizer(BaseEstimator, TransformerMixin):
     """
@@ -126,20 +128,18 @@ class FeatureUnhasher(BaseEstimator):
     def get_feature_names(self, always_signed=True):
         self.recalculate_attributes()
 
-        # names of unknown features
-        feature_names = np.array(
-            [self.unkn_template % i for i in range(self.n_features)],
-            dtype=object
-        )
-
         # lists of names with signs of known features
         column_ids, term_names, term_signs = self._get_collision_info()
+        feature_names = {}
         for col_id, names, signs in zip(column_ids, term_names, term_signs):
             if not always_signed and _invert_signs(signs):
                 signs = [-sign for sign in signs]
             feature_names[col_id] = [{'name': name, 'sign': sign}
-                             for name, sign in zip(names, signs)]
-        return feature_names
+                                     for name, sign in zip(names, signs)]
+        return FeatureNames(
+            feature_names,
+            n_features=self.n_features,
+            unkn_template=self.unkn_template)
 
     def recalculate_attributes(self, force=False):
         """

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -17,6 +17,7 @@ from eli5.sklearn.utils import (
     is_multiclass_classifier,
     is_multitarget_regressor,
     get_num_features,
+    FeatureNames,
 )
 
 
@@ -69,6 +70,9 @@ def test_get_feature_names():
         clf = LogisticRegression()
         clf.fit(X, y)
 
+        fnames = get_feature_names(clf, vec)
+        assert isinstance(fnames, FeatureNames)
+        assert repr(fnames) == '<FeatureNames: 2 features with bias>'
         assert _names(clf, vec) == {'hello', 'world', '<BIAS>'}
         assert _names(clf, vec, 'B') == {'hello', 'world', 'B'}
         assert _names(clf) == {'x0', 'x1', '<BIAS>'}
@@ -76,12 +80,18 @@ def test_get_feature_names():
         assert _names(clf, feature_names=['a', 'b'],
                                    bias_name='bias') == {'a', 'b', 'bias'}
         assert _names(clf, feature_names=np.array(['a', 'b'])) == {'a', 'b', '<BIAS>'}
+        assert _names(clf, feature_names=FeatureNames(['a', 'b'])) == {'a', 'b', '<BIAS>'}
+        assert _names(clf, feature_names=FeatureNames(
+            n_features=2, unkn_template='F%d')) == {'F0', 'F1', '<BIAS>'}
 
         with pytest.raises(ValueError):
             get_feature_names(clf, feature_names=['a'])
 
         with pytest.raises(ValueError):
             get_feature_names(clf, feature_names=['a', 'b', 'c'])
+
+        with pytest.raises(ValueError):
+            get_feature_names(clf, feature_names=FeatureNames(['a', 'b', 'c']))
 
         clf2 = LogisticRegression(fit_intercept=False)
         clf2.fit(X, y)


### PR DESCRIPTION
Store only defined feature names, store bias separately. There can be a very large number of features, so it's important to avoid making extra copies. So we store original ``feature_names`` in the class attribute, and bias in another attribute, and take advantage of sparsity for unknown feature names and for unhashed features (storing only known feature names).

This fixes #14 and issues I was trying to solve with #27 (now it's possible to pass ``FeatureNames`` class, this is already tested in ``test_explain_weights.py::test_explain_linear_hashed_pos_neg`` with ``pass_feature_weights=True``).