### PR TITLE
allow to print DecisionTreeClassifier as text or svg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python: 3.5
-sudo: false
+sudo: true
 branches:
     only:
         - master
@@ -19,6 +19,10 @@ addons:
             - libatlas-base-dev
             - liblapack-dev
             - gfortran
+
+before_install:
+    - sudo apt-get -qq update
+    - if [[ "$TOXENV" != "py35-nodeps" ]]; then sudo apt-get install graphviz; fi
 
 install:
     - pip install -U pip tox codecov

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,7 @@ Currently it allows to:
   and regressors;
 * explain weights of scikit-learn decision trees and tree-based ensemble
   classifiers (via feature importances);
+* text-based and svg-based scikit-learn decision tree visualization;
 * debug scikit-learn pipelines which contain HashingVectorizer,
   by undoing hashing;
 * explain weights and predictions of

--- a/eli5/_dot.py
+++ b/eli5/_dot.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import graphviz
+
+
+def dot2svg(dot):
+    """ Render Graphviz data to SVG """
+    svg = graphviz.Source(dot).pipe(format='svg').decode('utf8')
+    # strip doctype and xml declaration
+    svg = svg[svg.index('<svg'):]
+    return svg

--- a/eli5/_graphviz.py
+++ b/eli5/_graphviz.py
@@ -2,6 +2,14 @@
 import graphviz
 
 
+def is_supported():
+    try:
+        graphviz.Graph().pipe('svg')
+        return True
+    except RuntimeError:
+        return False
+
+
 def dot2svg(dot):
     """ Render Graphviz data to SVG """
     svg = graphviz.Source(dot).pipe(format='svg').decode('utf8')

--- a/eli5/formatters/fields.py
+++ b/eli5/formatters/fields.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-WEIGHTS = ('classes', 'targets', 'feature_importances')
+WEIGHTS = ('classes', 'targets', 'feature_importances', 'decision_tree')
 INFO = ('method', 'description',)
 ALL = INFO + WEIGHTS

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 import cgi
 from collections import Counter
 
@@ -8,6 +9,7 @@ from jinja2 import Environment, PackageLoader
 from .utils import format_signed, replace_spaces
 from . import fields
 from .features import FormattedFeatureName
+from .trees import tree2text
 
 
 template_env = Environment(
@@ -21,6 +23,7 @@ template_env.filters.update(dict(
     weight_range=lambda w: _weight_range(w),
     fi_weight_range=lambda w: max([abs(x[1]) for x in w] or [0]),
     format_feature=lambda f, w: _format_feature(f, w),
+    format_decision_tree=lambda tree: _format_decision_tree(tree),
 ))
 
 
@@ -199,6 +202,10 @@ def _format_single_feature(feature, weight):
             spaces='&emsp;' * n_spaces)
 
     return replace_spaces(html_escape(feature), replacer)
+
+
+def _format_decision_tree(treedict):
+    return tree2text(treedict)
 
 
 def html_escape(text):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -6,6 +6,7 @@ from collections import Counter
 import numpy as np
 from jinja2 import Environment, PackageLoader
 
+from eli5._dot import dot2svg
 from .utils import format_signed, replace_spaces
 from . import fields
 from .features import FormattedFeatureName
@@ -205,7 +206,10 @@ def _format_single_feature(feature, weight):
 
 
 def _format_decision_tree(treedict):
-    return tree2text(treedict)
+    if 'graphviz' in treedict:
+        return dot2svg(treedict['graphviz'])
+    else:
+        return tree2text(treedict)
 
 
 def html_escape(text):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -6,7 +6,7 @@ from collections import Counter
 import numpy as np
 from jinja2 import Environment, PackageLoader
 
-from eli5._dot import dot2svg
+from eli5 import _graphviz
 from .utils import format_signed, replace_spaces
 from . import fields
 from .features import FormattedFeatureName
@@ -206,8 +206,8 @@ def _format_single_feature(feature, weight):
 
 
 def _format_decision_tree(treedict):
-    if 'graphviz' in treedict:
-        return dot2svg(treedict['graphviz'])
+    if 'graphviz' in treedict and _graphviz.is_supported():
+        return _graphviz.dot2svg(treedict['graphviz'])
     else:
         return tree2text(treedict)
 

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -5,6 +5,7 @@ import six
 from . import fields
 from .features import FormattedFeatureName
 from .utils import format_signed, replace_spaces
+from .trees import tree2text
 
 
 _PLUS_MINUS = "+-" if six.PY2 else "±"
@@ -40,6 +41,11 @@ def format_as_text(explanation, show=fields.ALL):
                     plus=_PLUS_MINUS,
                     std=2*std,
                 ))
+
+        if key == 'decision_tree':
+            treedict = explanation['decision_tree']
+            lines.append("")
+            lines.append(_format_decision_tree(treedict))
 
     return '\n'.join(lines)
 
@@ -88,6 +94,10 @@ def _format_scores(proba, score):
     if score is not None:
         scores.append("score=%0.3f" % score)
     return ", ".join(scores)
+
+
+def _format_decision_tree(treedict):
+    return tree2text(treedict)
 
 
 def _maxlen(feature_weights):

--- a/eli5/formatters/trees.py
+++ b/eli5/formatters/trees.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+
+def tree2text(treedict, indent=4):
+    """
+    Return text representation of a decision tree.
+    """
+    parts = []
+
+    def _format_node(node, depth=0):
+        def p(*args):
+            parts.append(" " * depth * indent)
+            parts.extend(args)
+
+        if node['is_leaf']:
+            value = node['value_ratio']
+            value_repr = ", ".join("{:0.3f}".format(v) for v in value)
+            parts.append("  ---> [{value}]".format(value=value_repr))
+        else:
+            feat_name = node['feature_name']
+
+            if depth > 0:
+                parts.append("\n")
+            left_samples = node['left']['sample_ratio']
+            p("{feat_name} <= {threshold:0.3f}  ({left_samples:0.1%})".format(
+                left_samples=left_samples,
+                feat_name=feat_name,
+                **node
+            ))
+            _format_node(node["left"], depth=depth + 1)
+
+            parts.append("\n")
+            right_samples = node['right']['sample_ratio']
+            p("{feat_name} > {threshold:0.3f}  ({right_samples:0.1%})".format(
+                right_samples=right_samples,
+                feat_name=feat_name,
+                **node))
+            _format_node(node["right"], depth=depth + 1)
+
+    _format_node(treedict["tree"])
+    return "".join(parts)

--- a/eli5/sklearn/__init__.py
+++ b/eli5/sklearn/__init__.py
@@ -5,7 +5,7 @@ from .explain_weights import (
     explain_linear_classifier_weights,
     explain_linear_regressor_weights,
     explain_rf_feature_importance,
-    explain_tree_feature_importance,
+    explain_decision_tree,
 )
 from .explain_prediction import (
     explain_prediction_sklearn,

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -28,8 +28,7 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     ExtraTreesClassifier
 )
-from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.tree.export import export_graphviz
+from sklearn.tree import DecisionTreeClassifier
 
 from eli5._feature_weights import get_top_features_dict
 from eli5.utils import argsort_k_largest

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -231,7 +231,8 @@ def explain_rf_feature_importance(clf, vec=None, top=_TOP, target_names=None,
 
 @explain_weights_sklearn.register(DecisionTreeClassifier)
 def explain_decision_tree(clf, vec=None, top=_TOP, target_names=None,
-                          feature_names=None, coef_scale=None):
+                          feature_names=None, coef_scale=None,
+                          **export_graphviz_kwargs):
     """
     Return an explanation of a decision tree classifier in the
     following format (compatible with random forest explanations)::
@@ -253,7 +254,12 @@ def explain_decision_tree(clf, vec=None, top=_TOP, target_names=None,
     indices = argsort_k_largest(coef, top)
     names, values = feature_names[indices], coef[indices]
     std = np.zeros_like(values)
-    treedict = tree2dict(clf, feature_names=feature_names)
+    export_graphviz_kwargs.setdefault("proportion", True)
+    treedict = tree2dict(clf,
+                         feature_names=feature_names,
+                         class_names=target_names,
+                         **export_graphviz_kwargs)
+
     return {
         'feature_importances': list(zip(names, values, std)),
         'decision_tree': treedict,

--- a/eli5/sklearn/treeinspect.py
+++ b/eli5/sklearn/treeinspect.py
@@ -5,6 +5,7 @@ Inspect scikit-learn decision trees.
 This is an alternative to sklearn.tree.export which doesn't require graphviz
 and provides a way to output result in text-based format.
 """
+from __future__ import absolute_import, division
 from sklearn.tree import _tree
 
 

--- a/eli5/sklearn/treeinspect.py
+++ b/eli5/sklearn/treeinspect.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Inspect scikit-learn decision trees.
+
+This is an alternative to sklearn.tree.export which doesn't require graphviz
+and provides a way to output result in text-based format.
+"""
+from sklearn.tree import _tree
+
+
+def tree2dict(decision_tree, feature_names=None):
+    """
+    Convert DecisionTreeClassifier or DecisionTreeRegressor
+    to an inspectable dictionary.
+    """
+    res = {
+        "criterion": decision_tree.criterion,
+        "tree": _node2dict(decision_tree.tree_, 0),
+    }
+    _add_feature_names(res, feature_names)
+    return res
+
+
+def _add_feature_names(treedict, feature_names=None):
+    for node in _treeiter(treedict['tree']):
+        if not node['is_leaf']:
+            feat_id = node['feature_id']
+            if feature_names is None:
+                node['feature_name'] = "x%s" % feat_id
+            else:
+                node['feature_name'] = feature_names[feat_id]
+
+
+def _node2dict(tree, node_id):
+    is_leaf = tree.children_left[node_id] == _tree.TREE_LEAF
+    value = _node_value(tree, node_id)
+    node = {
+        "id": node_id,
+        "is_leaf": is_leaf,
+        "value": list(value),
+        "value_ratio": list(value / value.sum()),
+        "impurity": tree.impurity[node_id],
+        "samples": tree.n_node_samples[node_id],
+        "sample_ratio": tree.n_node_samples[node_id] / tree.n_node_samples[0],
+    }
+    if not is_leaf:
+        node["feature_id"] = tree.feature[node_id]
+        node["threshold"] = tree.threshold[node_id]
+        node["left"] = _node2dict(tree, tree.children_left[node_id])
+        node["right"] = _node2dict(tree, tree.children_right[node_id])
+    return node
+
+
+def _node_value(tree, node_id):
+    if tree.n_outputs == 1:
+        return tree.value[node_id][0, :]
+    else:
+        return tree.value[node_id]
+
+
+def _treeiter(node):
+    yield node
+    if not node['is_leaf']:
+        for n in _treeiter(node['left']):
+            yield n
+        for n in _treeiter(node['right']):
+            yield n

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -49,4 +49,11 @@
         </table>
     {% endif %}
 
+    {% if key == "decision_tree" and decision_tree %}
+        {# TODO - render a nice widget #}
+        <br>
+        <pre>{{ decision_tree|format_decision_tree }}</pre>
+    {% endif %}
+
+
 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'singledispatch >= 3.4.0.3',
         'six',
         'typing',
+        'graphviz',
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -182,15 +182,15 @@ def test_explain_linear_tuple_top(newsgroups_train):
 
 
 @pytest.mark.parametrize(['clf'], [
-    [RandomForestClassifier(n_estimators=100)],
-    [ExtraTreesClassifier(n_estimators=100)],
-    [GradientBoostingClassifier()],
-    [AdaBoostClassifier(learning_rate=0.1, n_estimators=200)],
-    [DecisionTreeClassifier()],
+    [RandomForestClassifier(n_estimators=100, random_state=42)],
+    [ExtraTreesClassifier(n_estimators=100, random_state=24)],
+    [GradientBoostingClassifier(random_state=42)],
+    [AdaBoostClassifier(learning_rate=0.1, n_estimators=200, random_state=42)],
+    [DecisionTreeClassifier(max_depth=3, random_state=42)],
 ])
 def test_explain_random_forest(newsgroups_train, clf):
     docs, y, target_names = newsgroups_train
-    vec = TfidfVectorizer()
+    vec = CountVectorizer()
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
 
@@ -200,7 +200,10 @@ def test_explain_random_forest(newsgroups_train, clf):
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:
         assert 'feature importances' in expl
-        assert 'that' in expl  # high-ranked feature
+        assert 'god' in expl  # high-ranked feature
+
+        if isinstance(clf, DecisionTreeClassifier):
+            assert 'god >' in expl  # TODO: better HTML tree visualisation
 
     assert res == get_res()
 

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -34,6 +34,7 @@ from sklearn.tree import DecisionTreeClassifier
 from sklearn.base import BaseEstimator
 import pytest
 
+from eli5 import _graphviz
 from eli5 import explain_weights
 from eli5.sklearn import InvertableHashingVectorizer
 from .utils import format_as_all, get_all_features, get_names_coefs
@@ -203,7 +204,10 @@ def test_explain_random_forest(newsgroups_train, clf):
         assert 'god' in expl  # high-ranked feature
 
     if isinstance(clf, DecisionTreeClassifier):
-        assert '<svg' in expl_html
+        if _graphviz.is_supported():
+            assert '<svg' in expl_html
+        else:
+            assert '<svg' not in expl_html
 
     assert res == get_res()
 

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -202,8 +202,8 @@ def test_explain_random_forest(newsgroups_train, clf):
         assert 'feature importances' in expl
         assert 'god' in expl  # high-ranked feature
 
-        if isinstance(clf, DecisionTreeClassifier):
-            assert 'god >' in expl  # TODO: better HTML tree visualisation
+    if isinstance(clf, DecisionTreeClassifier):
+        assert '<svg' in expl_html
 
     assert res == get_res()
 

--- a/tests/test_sklearn_treeinspect.py
+++ b/tests/test_sklearn_treeinspect.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from eli5.formatters.trees import tree2text
+from eli5.sklearn.treeinspect import tree2dict
+
+
+def test_tree2dict():
+    X = [[1, 1], [0, 2], [0, 3], [1, 3], [2, 3], [0, 4]]
+    y = [0, 0, 0, 1, 1, 1]
+    clf = DecisionTreeClassifier(random_state=42).fit(X, y)
+    text = tree2text(tree2dict(clf))
+    print(text)
+    expected = """
+x1 <= 2.500  (33.3%)  ---> [1.000, 0.000]
+x1 > 2.500  (66.7%)
+    x0 <= 0.500  (33.3%)
+        x1 <= 3.500  (16.7%)  ---> [1.000, 0.000]
+        x1 > 3.500  (16.7%)  ---> [0.000, 1.000]
+    x0 > 0.500  (33.3%)  ---> [0.000, 1.000]
+""".strip()
+    assert text == expected
+
+    # check it with feature_names
+    text = tree2text(tree2dict(clf, feature_names=['x', 'y']))
+    print(text)
+    expected = """
+y <= 2.500  (33.3%)  ---> [1.000, 0.000]
+y > 2.500  (66.7%)
+    x <= 0.500  (33.3%)
+        y <= 3.500  (16.7%)  ---> [1.000, 0.000]
+        y > 3.500  (16.7%)  ---> [0.000, 1.000]
+    x > 0.500  (33.3%)  ---> [0.000, 1.000]
+""".strip()
+    assert text == expected
+


### PR DESCRIPTION
Currently output looks like this:

```
petal width <= 2.450  (33.3%)  ---> [1.000, 0.000, 0.000]
petal width > 2.450  (66.7%)
    petal length <= 1.750  (36.0%)
        petal width <= 4.950  (32.0%)  ---> [0.000, 0.979, 0.021]
        petal width > 4.950  (4.0%)  ---> [0.000, 0.333, 0.667]
    petal length > 1.750  (30.7%)
        petal width <= 4.850  (2.0%)  ---> [0.000, 0.333, 0.667]
        petal width > 4.850  (28.7%)  ---> [0.000, 0.000, 1.000]
```