### PR TITLE
Improve is_probabilistic_classifier (fix lighting tests)

### DIFF
--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
-from sklearn.base import MetaEstimatorMixin
+from sklearn.multiclass import OneVsRestClassifier
 
 
 def is_multiclass_classifier(clf):
@@ -22,7 +22,9 @@ def is_probabilistic_classifier(clf):
     """ Return True if a classifier can return probabilities """
     if not hasattr(clf, 'predict_proba'):
         return False
-    if isinstance(clf, MetaEstimatorMixin) and hasattr(clf, 'estimator'):
+    if isinstance(clf, OneVsRestClassifier):
+        # It currently has a predict_proba method, but does not check if
+        # wrapped estimator has a predict_proba method.
         return hasattr(clf.estimator, 'predict_proba')
     return True
 

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
+from sklearn.base import MetaEstimatorMixin
 
 
 def is_multiclass_classifier(clf):
@@ -19,7 +20,11 @@ def is_multitarget_regressor(clf):
 
 def is_probabilistic_classifier(clf):
     """ Return True if a classifier can return probabilities """
-    return hasattr(clf, 'predict_proba')
+    if not hasattr(clf, 'predict_proba'):
+        return False
+    if isinstance(clf, MetaEstimatorMixin) and hasattr(clf, 'estimator'):
+        return hasattr(clf.estimator, 'predict_proba')
+    return True
 
 
 def has_intercept(estimator):


### PR DESCRIPTION
Try to look inside estimators that wrap other estimators: predict_proba can be a property in wrapped estimator but a method in wrapper estimator, so the AttributeError will be raised in
runtime. But we don't want to catch it in runtime because it might be unrelated. This fixes a failure that appeared after https://github.com/scikit-learn-contrib/lightning/pull/98/ merge (see https://travis-ci.org/TeamHG-Memex/eli5/jobs/172586529)