### PR TITLE
Format explanation as html in the notebook

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -2,10 +2,11 @@
 from __future__ import absolute_import
 import numpy as np
 
+from eli5.base import FeatureWeights
 from .utils import argsort_k_largest, argsort_k_smallest, mask
 
 
-def get_top_features(feature_names, coef, top):
+def _get_top_features(feature_names, coef, top):
     """
     Return a ``(pos, neg)`` tuple. ``pos`` and ``neg`` are lists of
     ``(name, value)`` tuples for features with positive and negative
@@ -31,20 +32,20 @@ def get_top_features(feature_names, coef, top):
     return pos, neg
 
 
-def get_top_features_dict(feature_names, coef, top):
-    pos, neg = get_top_features(feature_names, coef, top)
+def get_top_features(feature_names, coef, top):
+    pos, neg = _get_top_features(feature_names, coef, top)
     pos_coef = coef > 0
     neg_coef = coef < 0
     # pos_sum = sum(w for name, w in pos or [['', 0]])
     # neg_sum = sum(w for name, w in neg or [['', 0]])
-    return {
-        'pos': pos,
-        'neg': neg,
-        'pos_remaining': pos_coef.sum() - len(pos),
-        'neg_remaining': neg_coef.sum() - len(neg),
-        # 'pos_remaining_sum': coef[pos_coef].sum() - pos_sum,
-        # 'neg_remaining_sum': coef[neg_coef].sum() - neg_sum,
-    }
+    return FeatureWeights(
+         pos=pos,
+         neg=neg,
+         pos_remaining=pos_coef.sum() - len(pos),
+         neg_remaining=neg_coef.sum() - len(neg),
+         # pos_remaining_sum=coef[pos_coef].sum() - pos_sum,
+         # neg_remaining_sum=coef[neg_coef].sum() - neg_sum,
+    )
 
 
 def _get_top_abs_features(feature_names, coef, k):

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -14,7 +14,6 @@ class Explanation(object):
     decision_tree = attr.ib(default=None)
 
 
-# TODO - split into two classes?
 @attr.s
 class TargetExplanation(object):
     target = attr.ib()
@@ -28,8 +27,8 @@ class TargetExplanation(object):
 class FeatureWeights(object):
     pos = attr.ib()
     neg = attr.ib()
-    pos_remaining = attr.ib()
-    neg_remaining = attr.ib()
+    pos_remaining = attr.ib(default=0)
+    neg_remaining = attr.ib(default=0)
 
 
 @attr.s
@@ -37,4 +36,4 @@ class WeightedSpans(object):
     analyzer = attr.ib()
     document = attr.ib()
     weighted_spans = attr.ib()
-    other = attr.ib()
+    other = attr.ib(default=None)

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -37,3 +37,27 @@ class WeightedSpans(object):
     document = attr.ib()
     weighted_spans = attr.ib()
     other = attr.ib(default=None)
+
+
+@attr.s
+class TreeInfo(object):
+    criterion = attr.ib()
+    tree = attr.ib()
+    graphviz = attr.ib()
+
+
+@attr.s
+class NodeInfo(object):
+    id = attr.ib()
+    is_leaf = attr.ib()
+    value = attr.ib()
+    value_ratio = attr.ib()
+    impurity = attr.ib()
+    samples = attr.ib()
+    sample_ratio = attr.ib()
+    feature_name = attr.ib(default=None)
+    # for non-leafs
+    feature_id = attr.ib(default=None)
+    threshold = attr.ib(default=None)
+    left = attr.ib(default=None)
+    right = attr.ib(default=None)

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import attr
+
+
+@attr.s
+class Explanation(object):
+    estimator = attr.ib()
+    description = attr.ib()
+    method = attr.ib(default=None)
+    targets = attr.ib(default=None)
+    is_regression = attr.ib(default=False)
+    feature_importances = attr.ib(default=None)
+    decision_tree = attr.ib(default=None)
+
+
+# TODO - split into two classes?
+@attr.s
+class TargetExplanation(object):
+    target = attr.ib()
+    feature_weights = attr.ib()
+    proba = attr.ib(default=None)
+    score = attr.ib(default=None)
+
+
+@attr.s
+class FeatureWeights(object):
+    pos = attr.ib()
+    neg = attr.ib()
+    pos_remaining = attr.ib()
+    neg_remaining = attr.ib()
+

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -13,6 +13,10 @@ class Explanation(object):
     feature_importances = attr.ib(default=None)
     decision_tree = attr.ib(default=None)
 
+    def _repr_html_(self):
+        from eli5.formatters import format_as_html
+        return format_as_html(self, force_weights=False)
+
 
 @attr.s
 class TargetExplanation(object):

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -6,7 +6,7 @@ import attr
 @attr.s
 class Explanation(object):
     estimator = attr.ib()
-    description = attr.ib()
+    description = attr.ib(default=None)
     method = attr.ib(default=None)
     targets = attr.ib(default=None)
     is_regression = attr.ib(default=False)
@@ -21,6 +21,7 @@ class TargetExplanation(object):
     feature_weights = attr.ib()
     proba = attr.ib(default=None)
     score = attr.ib(default=None)
+    weighted_spans = attr.ib(default=None)
 
 
 @attr.s
@@ -30,3 +31,10 @@ class FeatureWeights(object):
     pos_remaining = attr.ib()
     neg_remaining = attr.ib()
 
+
+@attr.s
+class WeightedSpans(object):
+    analyzer = attr.ib()
+    document = attr.ib()
+    weighted_spans = attr.ib()
+    other = attr.ib()

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -14,8 +14,8 @@ class Explanation(object):
     decision_tree = attr.ib(default=None)
 
     def _repr_html_(self):
-        from eli5.formatters import format_as_html
-        return format_as_html(self, force_weights=False)
+        from eli5.formatters import format_as_html, fields
+        return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
 
 
 @attr.s

--- a/eli5/formatters/fields.py
+++ b/eli5/formatters/fields.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-WEIGHTS = ('classes', 'targets', 'feature_importances', 'decision_tree')
+WEIGHTS = ('targets', 'feature_importances', 'decision_tree')
 INFO = ('method', 'description',)
 ALL = INFO + WEIGHTS

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -206,8 +206,8 @@ def _format_single_feature(feature, weight):
 
 
 def _format_decision_tree(treedict):
-    if 'graphviz' in treedict and _graphviz.is_supported():
-        return _graphviz.dot2svg(treedict['graphviz'])
+    if treedict.graphviz and _graphviz.is_supported():
+        return _graphviz.dot2svg(treedict.graphviz)
     else:
         return tree2text(treedict)
 

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -70,9 +70,9 @@ def render_weighted_spans(weighted_spans_data, preserve_density=None):
     and not preserved for "word" analyzers.
     """
     if preserve_density is None:
-        preserve_density = weighted_spans_data['analyzer'].startswith('char')
-    doc = weighted_spans_data['document']
-    weighted_spans = weighted_spans_data['weighted_spans']
+        preserve_density = weighted_spans_data.analyzer.startswith('char')
+    doc = weighted_spans_data.document
+    weighted_spans = weighted_spans_data.weighted_spans
     char_weights = np.zeros(len(doc))
     feature_counts = Counter(f for f, _, _ in weighted_spans)
     for feature, spans, weight in weighted_spans:

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -50,7 +50,7 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none;',
         td2_styles='padding: 0 0.5em 0 0.5em; text-align: left; border: none;',
         show=show,
-        **explanation)
+        expl=explanation)
 
 
 def format_html_styles():
@@ -140,8 +140,8 @@ def _hue(weight):
 def _weight_range(weights):
     """ Max absolute feature for pos and neg weights.
     """
-    return max([abs(coef) for key in ['pos', 'neg']
-                for _, coef in weights.get(key, [])] or [0])
+    return max([abs(coef) for lst in [weights.pos, weights.neg]
+                for _, coef in lst or []] or [0])
 
 
 def _remaining_weight_color(ws, weight_range, pos_neg):

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -13,76 +13,57 @@ _ELLIPSIS = '...' if six.PY2 else '…'
 _SPACE = '_' if six.PY2 else '░'
 
 
-def format_as_text(explanation, show=fields.ALL):
+def format_as_text(expl, show=fields.ALL):
     lines = []
 
-    for key in show:
-        if key not in explanation:
-            continue
+    if 'method' in show and expl.method:
+        lines.append('Explained as: {}'.format(expl.method))
 
-        if key == 'method':
-            lines.append('Explained as: {}'.format(explanation['method']))
+    if 'description' in show and expl.description:
+        lines.append(expl.description)
 
-        if key == 'description':
-            lines.append(explanation['description'])
+    if 'targets' in show and expl.targets:
+        lines.extend(_format_weights(expl))
 
-        if key == 'classes':
-            lines.extend(_format_weights(explanation['classes']))
+    if 'feature_importances' in show and expl.feature_importances:
+        sz = _maxlen(expl.feature_importances)
+        for name, w, std in expl.feature_importances:
+            lines.append('{w:0.4f} {plus} {std:0.4f} {feature}'.format(
+                feature=name.ljust(sz),
+                w=w,
+                plus=_PLUS_MINUS,
+                std=2*std,
+            ))
 
-        if key == 'targets':
-            lines.extend(_format_weights(explanation['targets']))
-
-        if key == 'feature_importances':
-            sz = _maxlen(explanation['feature_importances'])
-            for name, w, std in explanation['feature_importances']:
-                lines.append('{w:0.4f} {plus} {std:0.4f} {feature}'.format(
-                    feature=name.ljust(sz),
-                    w=w,
-                    plus=_PLUS_MINUS,
-                    std=2*std,
-                ))
-
-        if key == 'decision_tree':
-            treedict = explanation['decision_tree']
-            lines.append("")
-            lines.append(_format_decision_tree(treedict))
+    if 'decision_tree' in show and expl.decision_tree:
+        lines.append("")
+        lines.append(_format_decision_tree(expl.decision_tree))
 
     return '\n'.join(lines)
 
 
-def _format_weights(explanations):
+def _format_weights(explanation):
     lines = []
-    sz = _max_feature_size(explanations)
-    for explanation in explanations:
-        scores = _format_scores(
-            explanation.get('proba'),
-            explanation.get('score'),
-        )
+    sz = _max_feature_size(explanation.targets)
+    for target in explanation.targets:
+        scores = _format_scores(target.proba, target.score)
         if scores:
             scores = " (%s)" % scores
 
-        if 'class' in explanation:
-            header = "y=%r%s top features" % (
-                explanation['class'],
-                scores
-            )
-        elif 'target' in explanation:
-            header = "%r%s top features" % (
-                explanation['target'],
-                scores
-            )
-        else:
-            raise ValueError('Expected "class" or "target" key')
+        header = "%s%r%s top features" % (
+            'y=' if not explanation.is_regression else '',
+            target.target,
+            scores)
         lines.append(header)
         lines.append("-" * (sz + 10))
 
-        w = explanation['feature_weights']
-        lines.extend(_format_feature_weights(w['pos'], sz))
-        if w['pos_remaining']:
-            lines.append(_format_remaining(w['pos_remaining'], 'positive'))
-        if w['neg_remaining']:
-            lines.append(_format_remaining(w['neg_remaining'], 'negative'))
-        lines.extend(_format_feature_weights(w['neg'], sz))
+        w = target.feature_weights
+        lines.extend(_format_feature_weights(w.pos, sz))
+        if w.pos_remaining:
+            lines.append(_format_remaining(w.pos_remaining, 'positive'))
+        if w.neg_remaining:
+            lines.append(_format_remaining(w.neg_remaining, 'negative'))
+        lines.extend(_format_feature_weights(w.neg, sz))
         lines.append("")
     return lines
 
@@ -108,8 +89,8 @@ def _maxlen(feature_weights):
 
 def _max_feature_size(explanation):
     def _max_feature_length(w):
-        return _maxlen(w['pos'] + w['neg'])
-    return max(_max_feature_length(e['feature_weights']) for e in explanation)
+        return _maxlen(w.pos + w.neg)
+    return max(_max_feature_length(e.feature_weights) for e in explanation)
 
 
 def _format_feature_weights(feature_weights, sz):

--- a/eli5/formatters/trees.py
+++ b/eli5/formatters/trees.py
@@ -12,30 +12,31 @@ def tree2text(treedict, indent=4):
             parts.append(" " * depth * indent)
             parts.extend(args)
 
-        if node['is_leaf']:
-            value = node['value_ratio']
+        if node.is_leaf:
+            value = node.value_ratio
             value_repr = ", ".join("{:0.3f}".format(v) for v in value)
             parts.append("  ---> [{value}]".format(value=value_repr))
         else:
-            feat_name = node['feature_name']
+            feat_name = node.feature_name
 
             if depth > 0:
                 parts.append("\n")
-            left_samples = node['left']['sample_ratio']
+            left_samples = node.left.sample_ratio
             p("{feat_name} <= {threshold:0.3f}  ({left_samples:0.1%})".format(
                 left_samples=left_samples,
                 feat_name=feat_name,
-                **node
+                threshold=node.threshold,
             ))
-            _format_node(node["left"], depth=depth + 1)
+            _format_node(node.left, depth=depth + 1)
 
             parts.append("\n")
-            right_samples = node['right']['sample_ratio']
+            right_samples = node.right.sample_ratio
             p("{feat_name} > {threshold:0.3f}  ({right_samples:0.1%})".format(
                 right_samples=right_samples,
                 feat_name=feat_name,
-                **node))
-            _format_node(node["right"], depth=depth + 1)
+                threshold=node.threshold,
+                ))
+            _format_node(node.right, depth=depth + 1)
 
-    _format_node(treedict["tree"])
+    _format_node(treedict.tree)
     return "".join(parts)

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -48,10 +48,10 @@ _TOP = 20
 def explain_prediction_sklearn(estimator, doc, vec=None, top=_TOP, target_names=None,
                                feature_names=None, vectorized=False):
     """ Return an explanation of a scikit-learn estimator """
-    return {
-        "estimator": repr(estimator),
-        "description": "Error: estimator %r is not supported" % estimator,
-    }
+    return Explanation(
+        estimator=repr(estimator),
+        description="Error: estimator %r is not supported" % estimator,
+    )
 
 
 @explain_prediction.register(OneVsRestClassifier)

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -35,7 +35,7 @@ from eli5.sklearn.utils import (
     rename_label,
 )
 from eli5.sklearn.text import get_weighted_spans
-from eli5._feature_weights import get_top_features_dict
+from eli5._feature_weights import get_top_features
 from eli5.explain import explain_prediction
 
 
@@ -104,7 +104,7 @@ def explain_prediction_linear_classifier(
     def _weights(label_id):
         coef = get_coef(clf, label_id)
         scores = _multiply(x, coef)
-        return get_top_features_dict(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top)
 
     def _label(label_id, label):
         return rename_label(label_id, label, target_names)
@@ -209,7 +209,7 @@ def explain_prediction_linear_regressor(
     def _weights(label_id):
         coef = get_coef(reg, label_id)
         scores = _multiply(x, coef)
-        return get_top_features_dict(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top)
 
     def _label(label_id, label):
         return rename_label(label_id, label, target_names)

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -344,6 +344,7 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
             description=DESCRIPTION_REGRESSION_MULTITARGET + _extra_caveats,
             estimator=repr(reg),
             method='linear model',
+            is_regression=True,
         )
     else:
         return Explanation(
@@ -354,4 +355,5 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
             description=DESCRIPTION_REGRESSION + _extra_caveats,
             estimator=repr(reg),
             method='linear model',
+            is_regression=True,
         )

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -34,7 +34,7 @@ from eli5.base import Explanation, TargetExplanation
 from eli5._feature_weights import get_top_features
 from eli5.utils import argsort_k_largest
 from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing
-from eli5.sklearn.treeinspect import tree2dict
+from eli5.sklearn.treeinspect import get_tree_info
 from eli5.sklearn.utils import (
     get_coef,
     is_multiclass_classifier,
@@ -254,14 +254,15 @@ def explain_decision_tree(clf, vec=None, top=_TOP, target_names=None,
     names, values = feature_names[indices], coef[indices]
     std = np.zeros_like(values)
     export_graphviz_kwargs.setdefault("proportion", True)
-    treedict = tree2dict(clf,
-                         feature_names=feature_names,
-                         class_names=target_names,
-                         **export_graphviz_kwargs)
+    tree_info = get_tree_info(
+        clf,
+        feature_names=feature_names,
+        class_names=target_names,
+        **export_graphviz_kwargs)
 
     return Explanation(
         feature_importances=list(zip(names, values, std)),
-        decision_tree=treedict,
+        decision_tree=tree_info,
         description=DESCRIPTION_DECISION_TREE,
         estimator=repr(clf),
         method='decision tree',

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -30,7 +30,8 @@ from sklearn.ensemble import (
 )
 from sklearn.tree import DecisionTreeClassifier
 
-from eli5._feature_weights import get_top_features_dict
+from eli5.base import Explanation, TargetExplanation
+from eli5._feature_weights import get_top_features
 from eli5.utils import argsort_k_largest
 from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing
 from eli5.sklearn.treeinspect import tree2dict
@@ -98,10 +99,10 @@ _TOP = 20
 def explain_weights_sklearn(estimator, vec=None, top=_TOP, target_names=None,
                             feature_names=None, coef_scale=None):
     """ Return an explanation of an estimator """
-    return {
-        "estimator": repr(estimator),
-        "description": "Error: estimator %r is not supported" % estimator,
-    }
+    return Explanation(
+        estimator=repr(estimator),
+        description="Error: estimator %r is not supported" % estimator,
+    )
 
 
 @explain_weights_sklearn.register(LogisticRegression)
@@ -116,41 +117,38 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
     Return an explanation of a linear classifier weights in the following
     format::
 
-        {
-            "estimator": "<classifier repr>",
-            "method": "<interpretation method>",
-            "description": "<human readable description>",
-            "classes": [
-                {
-                    "class": <class name>,
-                    "feature_weights": [
-                        {
-                            # positive weights
-                            "pos": [
-                                (feature_name, coefficient),
-                                ...
-                            ],
+        Explanation(
+            estimator="<classifier repr>",
+            method="<interpretation method>",
+            description="<human readable description>",
+            targets=[
+                TargetExplanation(
+                    target="<class name>",
+                    feature_weights=FeatureWeights(
+                        # positive weights
+                        pos=[
+                            (feature_name, coefficient),
+                            ...
+                        ],
 
-                            # negative weights
-                            "neg": [
-                                (feature_name, coefficient),
-                                ...
-                            ],
+                        # negative weights
+                        neg=[
+                            (feature_name, coefficient),
+                            ...
+                        ],
 
-                            # A number of features not shown
-                            "pos_remaining": <int>,
-                            "neg_remaining": <int>,
+                        # A number of features not shown
+                        pos_remaining = <int>,
+                        neg_remaining = <int>,
 
-                            # Sum of feature weights not shown
-                            # "pos_remaining_sum": <float>,
-                            # "neg_remaining_sum": <float>,
-                        },
-                        ...
-                    ]
-                },
+                        # Sum of feature weights not shown
+                        # pos_remaining_sum = <float>,
+                        # neg_remaining_sum = <float>,
+                    ),
+                ),
                 ...
             ]
-        }
+        )
 
     To print it use utilities from eli5.formatters.
     """
@@ -161,36 +159,38 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
 
     def _features(label_id):
         coef = get_coef(clf, label_id, scale=coef_scale)
-        return get_top_features_dict(feature_names, coef, top)
+        return get_top_features(feature_names, coef, top)
 
     def _label(label_id, label):
         return rename_label(label_id, label, target_names)
 
     if is_multiclass_classifier(clf):
-        return {
-            'classes': [
-                {
-                    'class': _label(label_id, label),
-                    'feature_weights': _features(label_id)
-                }
+        return Explanation(
+            targets=[
+                TargetExplanation(
+                    target=_label(label_id, label),
+                    feature_weights=_features(label_id)
+                )
                 for label_id, label in enumerate(clf.classes_)
             ],
-            'description': DESCRIPTION_CLF_MULTICLASS + _extra_caveats,
-            'estimator': repr(clf),
-            'method': 'linear model',
-        }
+            description=DESCRIPTION_CLF_MULTICLASS + _extra_caveats,
+            estimator=repr(clf),
+            method='linear model',
+        )
     else:
         # for binary classifiers scikit-learn stores a single coefficient
         # vector, which corresponds to clf.classes_[1].
-        return {
-            'classes': [{
-                'class': _label(1, clf.classes_[1]),
-                'feature_weights': _features(0),
-            }],
-            'description': DESCRIPTION_CLF_BINARY + _extra_caveats,
-            'estimator': repr(clf),
-            'method': 'linear model',
-        }
+        return Explanation(
+            targets=[
+                TargetExplanation(
+                    target=_label(1, clf.classes_[1]),
+                    feature_weights=_features(0),
+                )
+            ],
+            description=DESCRIPTION_CLF_BINARY + _extra_caveats,
+            estimator=repr(clf),
+            method='linear model',
+        )
 
 
 @explain_weights_sklearn.register(RandomForestClassifier)
@@ -203,15 +203,15 @@ def explain_rf_feature_importance(clf, vec=None, top=_TOP, target_names=None,
     Return an explanation of a tree-based ensemble classifier in the
     following format::
 
-        {
-            "estimator": "<classifier repr>",
-            "method": "<interpretation method>",
-            "description": "<human readable description>",
-            "feature_importances": [
+        Explanation(
+            estimator="<classifier repr>",
+            method="<interpretation method>",
+            description="<human readable description>",
+            feature_importances=[
                 (feature_name, importance, std_deviation),
                 ...
             ]
-        }
+        )
     """
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
     coef = clf.feature_importances_
@@ -220,12 +220,12 @@ def explain_rf_feature_importance(clf, vec=None, top=_TOP, target_names=None,
 
     indices = argsort_k_largest(coef, top)
     names, values, std = feature_names[indices], coef[indices], coef_std[indices]
-    return {
-        'feature_importances': list(zip(names, values, std)),
-        'description': DESCRIPTION_RANDOM_FOREST,
-        'estimator': repr(clf),
-        'method': 'feature importances',
-    }
+    return Explanation(
+        feature_importances=list(zip(names, values, std)),
+        description=DESCRIPTION_RANDOM_FOREST,
+        estimator=repr(clf),
+        method='feature importances',
+    )
 
 
 @explain_weights_sklearn.register(DecisionTreeClassifier)
@@ -236,16 +236,16 @@ def explain_decision_tree(clf, vec=None, top=_TOP, target_names=None,
     Return an explanation of a decision tree classifier in the
     following format (compatible with random forest explanations)::
 
-        {
-            "estimator": "<classifier repr>",
-            "method": "<interpretation method>",
-            "description": "<human readable description>",
-            "decision_tree": {...tree information},
-            "feature_importances": [
+        Explanation(
+            estimator="<classifier repr>",
+            method="<interpretation method>",
+            description="<human readable description>",
+            decision_tree={...tree information},
+            feature_importances=[
                 (feature_name, importance, std_deviation),
                 ...
             ]
-        }
+        )
 
     """
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
@@ -259,13 +259,13 @@ def explain_decision_tree(clf, vec=None, top=_TOP, target_names=None,
                          class_names=target_names,
                          **export_graphviz_kwargs)
 
-    return {
-        'feature_importances': list(zip(names, values, std)),
-        'decision_tree': treedict,
-        'description': DESCRIPTION_DECISION_TREE,
-        'estimator': repr(clf),
-        'method': 'decision tree',
-    }
+    return Explanation(
+        feature_importances=list(zip(names, values, std)),
+        decision_tree=treedict,
+        description=DESCRIPTION_DECISION_TREE,
+        estimator=repr(clf),
+        method='decision tree',
+    )
 
 
 @explain_weights_sklearn.register(ElasticNet)
@@ -283,41 +283,38 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
     Return an explanation of a linear regressor weights in the following
     format::
 
-        {
-            "estimator": "<regressor repr>",
-            "method": "<interpretation method>",
-            "description": "<human readable description>",
-            "targets": [
-                {
-                    "target": "<target name>",
-                    "feature_weights": [
-                        {
-                            # positive weights
-                            "pos": [
-                                (feature_name, coefficient),
-                                ...
-                            ],
+        Explanation(
+            estimator="<regressor repr>",
+            method="<interpretation method>",
+            description="<human readable description>",
+            targets=[
+                TargetExplanation(
+                    target="<target name>",
+                    feature_weights=FeatureWeights(
+                        # positive weights
+                        pos=[
+                            (feature_name, coefficient),
+                            ...
+                        ],
 
-                            # negative weights
-                            "neg": [
-                                (feature_name, coefficient),
-                                ...
-                            ],
+                        # negative weights
+                        neg=[
+                            (feature_name, coefficient),
+                            ...
+                        ],
 
-                            # A number of features not shown
-                            "pos_remaining": <int>,
-                            "neg_remaining": <int>,
+                        # A number of features not shown
+                        pos_remaining = <int>,
+                        neg_remaining = <int>,
 
-                            # Sum of feature weights not shown
-                            # "pos_remaining_sum": <float>,
-                            # "neg_remaining_sum": <float>,
-                        },
-                        ...
-                    ]
-                },
+                        # Sum of feature weights not shown
+                        # pos_remaining_sum = <float>,
+                        # neg_remaining_sum = <float>,
+                    ),
+                ),
                 ...
             ]
-        }
+        )
 
     To print it use utilities from eli5.formatters.
     """
@@ -328,7 +325,7 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
 
     def _features(target_id):
         coef = get_coef(reg, target_id, scale=coef_scale)
-        return get_top_features_dict(feature_names, coef, top)
+        return get_top_features(feature_names, coef, top)
 
     def _label(target_id, target):
         return rename_label(target_id, target, target_names)
@@ -336,25 +333,25 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
     if is_multitarget_regressor(reg):
         if target_names is None:
             target_names = get_target_names(reg)
-        return {
-            'targets': [
-                {
-                    'target': _label(target_id, target),
-                    'feature_weights': _features(target_id)
-                }
+        return Explanation(
+            targets=[
+                TargetExplanation(
+                    target=_label(target_id, target),
+                    feature_weights=_features(target_id)
+                )
                 for target_id, target in enumerate(target_names)
                 ],
-            'description': DESCRIPTION_REGRESSION_MULTITARGET + _extra_caveats,
-            'estimator': repr(reg),
-            'method': 'linear model',
-        }
+            description=DESCRIPTION_REGRESSION_MULTITARGET + _extra_caveats,
+            estimator=repr(reg),
+            method='linear model',
+        )
     else:
-        return {
-            'targets': [{
-                'target': _label(0, 'y'),
-                'feature_weights': _features(0),
-            }],
-            'description': DESCRIPTION_REGRESSION + _extra_caveats,
-            'estimator': repr(reg),
-            'method': 'linear model',
-        }
+        return Explanation(
+            targets=[TargetExplanation(
+                target=_label(0, 'y'),
+                feature_weights=_features(0),
+            )],
+            description=DESCRIPTION_REGRESSION + _extra_caveats,
+            estimator=repr(reg),
+            method='linear model',
+        )

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -3,6 +3,7 @@ import re
 from six.moves import xrange
 from sklearn.feature_extraction.text import VectorizerMixin
 
+from eli5.base import WeightedSpans, FeatureWeights
 from eli5.sklearn.unhashing import InvertableHashingVectorizer
 from eli5.formatters import FormattedFeatureName
 
@@ -25,7 +26,7 @@ def get_weighted_spans(doc, vec, feature_weights):
     # (group, idx) is a feature key here
     feature_weights_dict = {
         f: (weight, (group, idx)) for group in ['pos', 'neg']
-        for idx, (feature, weight) in enumerate(feature_weights[group])
+        for idx, (feature, weight) in enumerate(getattr(feature_weights, group))
         for f in _get_features(feature)}
 
     span_analyzer, preprocessed_doc = _build_span_analyzer(doc, vec)
@@ -43,13 +44,13 @@ def get_weighted_spans(doc, vec, feature_weights):
             weighted_spans.append((feature, spans, weight))
             found_features[key] = weight
 
-    return {
-        'analyzer': vec.analyzer,
-        'document': preprocessed_doc,
-        'weighted_spans': weighted_spans,
-        'other': _get_other(
+    return WeightedSpans(
+        analyzer=vec.analyzer,
+        document=preprocessed_doc,
+        weighted_spans=weighted_spans,
+        other=_get_other(
             feature_weights, feature_weights_dict, found_features),
-    }
+    )
 
 
 def _get_other(feature_weights, feature_weights_dict, found_features):
@@ -59,21 +60,19 @@ def _get_other(feature_weights, feature_weights_dict, found_features):
     for feature, (_, key) in feature_weights_dict.items():
         if key not in found_features and key not in accounted_keys:
             group, idx = key
-            other_items.append(feature_weights[group][idx])
+            other_items.append(getattr(feature_weights, group)[idx])
             accounted_keys.add(key)
     if found_features:
         other_items.append(
             (FormattedFeatureName('Highlighted in text (sum)'),
              sum(found_features.values())))
     other_items.sort(key=lambda x: abs(x[1]), reverse=True)
-    other = {
-        'pos': [(f, w) for f, w in other_items if w >= 0],
-        'neg': [(f, w) for f, w in other_items if w < 0],
-    }
-    for key in ['pos_remaining', 'neg_remaining']:
-        if feature_weights.get(key):
-            other[key] = feature_weights[key]
-    return other
+    return FeatureWeights(
+        pos=[(f, w) for f, w in other_items if w >= 0],
+        neg=[(f, w) for f, w in other_items if w < 0],
+        pos_remaining=feature_weights.pos_remaining,
+        neg_remaining=feature_weights.neg_remaining,
+    )
 
 
 def _build_span_analyzer(document, vec):

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -3,28 +3,20 @@
 {% endif %}
 
 {% for key in show %}
-    {% if key == "method" and method %}
-        <p>Explained as: {{ method }}</p>
+    {% if key == "method" and expl.method %}
+        <p>Explained as: {{ expl.method }}</p>
     {% endif %}
 
-    {% if key == "description" and description %}
+    {% if key == "description" and expl.description %}
         {# TODO - have a structured prepresentation and convert it to html and text #}
-        <pre>{{ description }}</pre>
+        <pre>{{ expl.description }}</pre>
     {% endif %}
 
-    {% if key == "classes" and classes %}
-        {% with explanations = classes %}
+    {% if key == "targets" and expl.targets %}
         {% include "weights.html" with context %}
-        {% endwith %}
     {% endif %}
 
-    {% if key == "targets" and targets %}
-        {% with explanations = targets %}
-            {% include "weights.html" with context %}
-        {% endwith %}
-    {% endif %}
-
-    {% if key == "feature_importances" and feature_importances %}
+    {% if key == "feature_importances" and expl.feature_importances %}
         <table class="eli5-weights" style="{{ table_styles }}">
             <thead>
             <tr style="{{ tr_styles }}">
@@ -33,8 +25,8 @@
             </tr>
             </thead>
             <tbody>
-            {% with weight_range = feature_importances|fi_weight_range %}
-                {% for name, w, std in feature_importances %}
+            {% with weight_range = expl.feature_importances|fi_weight_range %}
+                {% for name, w, std in expl.feature_importances %}
                     <tr style="background-color: {{ w|weight_color(weight_range) }}; {{ tr_styles }}">
                         <td style="{{ td1_styles }}">
                             {{ "%0.4f"|format(w) }} &plusmn; {{ "%0.4f"|format(2 * std) }}
@@ -49,10 +41,10 @@
         </table>
     {% endif %}
 
-    {% if key == "decision_tree" and decision_tree %}
+    {% if key == "decision_tree" and expl.decision_tree %}
         {# TODO - render a nice widget #}
         <br>
-        <pre>{{ decision_tree|format_decision_tree }}</pre>
+        <pre>{{ expl.decision_tree|format_decision_tree }}</pre>
     {% endif %}
 
 

--- a/eli5/templates/weights.html
+++ b/eli5/templates/weights.html
@@ -1,39 +1,39 @@
-{% for expl in explanations %}
+{% for target in expl.targets %}
 
     <p>
         <b>
-            {% if expl.class is defined %}
-                y={{ expl.class }}
-            {% elif expl.target is defined %}
-                {{ expl.target }}
+            {% if expl.is_regression -%}
+                {{ target.target }}
+            {% else %}
+                y={{ target.target }}
             {% endif %}
         </b>
-        {% if expl.proba is defined or expl.score is defined %}
+        {% if target.proba is not none or target.score is not none %}
             {% set comma = joiner(", ") %}
             (
-            {%- if expl.proba is defined -%}
-                {{ comma() }}probability <b>{{ "%0.3f"|format(expl.proba) }}</b>
+            {%- if target.proba is not none -%}
+                {{ comma() }}probability <b>{{ "%0.3f"|format(target.proba) }}</b>
             {%- endif -%}
-            {%- if expl.score is defined -%}
-                {{ comma() }}score <b>{{ "%0.3f"|format(expl.score) }}</b>
+            {%- if target.score is not none -%}
+                {{ comma() }}score <b>{{ "%0.3f"|format(target.score) }}</b>
             {%- endif -%}
             )
         {% endif %}
         top features
     </p>
 
-    {% if force_weights or not expl.weighted_spans is defined %}
-        {% with wts = expl.feature_weights %}
+    {% if force_weights or not target.weighted_spans %}
+        {% with wts = target.feature_weights %}
             {% include "weights_table.html" with context %}
         {% endwith %}
     {% endif %}
 
-    {% if expl.weighted_spans %}
-        {% with wts = expl.weighted_spans.other %}
+    {% if target.weighted_spans %}
+        {% with wts = target.weighted_spans.other %}
             {% include "weights_table.html" with context %}
         {% endwith %}
         <p>
-            {{ expl.weighted_spans|render_weighted_spans(preserve_density) }}
+            {{ target.weighted_spans|render_weighted_spans(preserve_density) }}
         </p>
     {% endif %}
 

--- a/eli5/templates/weights.html
+++ b/eli5/templates/weights.html
@@ -2,7 +2,7 @@
 
     <p>
         <b>
-            {% if expl.is_regression -%}
+            {% if expl.is_regression %}
                 {{ target.target }}
             {% else %}
                 y={{ target.target }}

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     include_package_data=True,
     packages=find_packages(exclude=['tests']),
     install_requires=[
+        'attrs',
         'jinja2',
         'numpy >= 1.9.0',
         'scipy',

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -1,5 +1,6 @@
 import re
 
+from eli5.base import WeightedSpans
 from eli5.formatters import format_html_styles, FormattedFeatureName
 from eli5.formatters.html import (
     _format_unhashed_feature, render_weighted_spans, _format_single_feature,
@@ -66,15 +67,15 @@ def test_format_single_feature():
 
 
 def test_render_weighted_spans_word():
-    weighted_spans = {
-        'analyzer': 'word',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+    weighted_spans = WeightedSpans(
+        analyzer='word',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 0.2),
             ('tree', [(23, 27)], -0.6),
             ('leaning lemon', [(9, 16), (17, 22)], 0.5),
             ('lemon tree', [(17, 22), (23, 27)], 0.8)],
-    }
+    )
     s = render_weighted_spans(weighted_spans)
     assert s.startswith(
         '<span style="opacity: 0.80">i</span>'
@@ -116,14 +117,14 @@ def test_render_weighted_spans_word():
 
 
 def test_render_weighted_spans_char():
-    weighted_spans = {
-        'analyzer': 'char',
-        'document': 'see',
-        'weighted_spans': [
+    weighted_spans = WeightedSpans(
+        analyzer='char',
+        document='see',
+        weighted_spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
             ],
-    }
+    )
     s = render_weighted_spans(weighted_spans)
     assert s == (
         '<span'
@@ -139,14 +140,14 @@ def test_render_weighted_spans_char():
 
 
 def test_override_preserve_density():
-    weighted_spans = {
-        'analyzer': 'char',
-        'document': 'see',
-        'weighted_spans': [
+    weighted_spans = WeightedSpans(
+        analyzer='char',
+        document='see',
+        weighted_spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
         ],
-    }
+    )
     s = render_weighted_spans(weighted_spans, preserve_density=False)
     assert s.startswith(
         '<span '

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -42,10 +42,10 @@ def assert_multiclass_linear_classifier_explained(newsgroups_train, clf,
     pprint(res)
     expl_text, expl_html = format_as_all(res, clf)
 
-    for e in res['classes']:
-        if e['class'] != 'comp.graphics':
+    for e in res.targets:
+        if e.target != 'comp.graphics':
             continue
-        pos = get_all_features(e['feature_weights']['pos'])
+        pos = get_all_features(e.feature_weights.pos)
         assert 'file' in pos
 
     for expl in [expl_text, expl_html]:
@@ -62,11 +62,11 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction):
     res = explain_prediction(reg, X[0])
     expl_text, expl_html = format_as_all(res, reg)
 
-    assert len(res['targets']) == 1
-    target = res['targets'][0]
-    assert target['target'] == 'y'
-    pos, neg = (get_all_features(target['feature_weights']['pos']),
-                get_all_features(target['feature_weights']['neg']))
+    assert len(res.targets) == 1
+    target = res.targets[0]
+    assert target.target == 'y'
+    pos, neg = (get_all_features(target.feature_weights.pos),
+                get_all_features(target.feature_weights.neg))
     assert 'x11' in pos or 'x11' in neg
 
     if has_intercept(reg):
@@ -94,11 +94,11 @@ def assert_multitarget_linear_regression_explained(reg, explain_prediction):
     res = explain_prediction(reg, X[0])
     expl_text, expl_html = format_as_all(res, reg)
 
-    assert len(res['targets']) == 3
-    target = res['targets'][1]
-    assert target['target'] == 'y1'
-    pos, neg = (get_all_features(target['feature_weights']['pos']),
-                get_all_features(target['feature_weights']['neg']))
+    assert len(res.targets) == 3
+    target = res.targets[1]
+    assert target.target == 'y1'
+    pos, neg = (get_all_features(target.feature_weights.pos),
+                get_all_features(target.feature_weights.neg))
     assert 'x8' in pos or 'x8' in neg
     assert '<BIAS>' in pos or '<BIAS>' in neg
 

--- a/tests/test_sklearn_text.py
+++ b/tests/test_sklearn_text.py
@@ -1,5 +1,6 @@
 from sklearn.feature_extraction.text import CountVectorizer
 
+from eli5.base import WeightedSpans, FeatureWeights
 from eli5.formatters import FormattedFeatureName
 from eli5.sklearn.text import get_weighted_spans
 
@@ -13,20 +14,23 @@ def test_weighted_spans_word():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {'pos': [('see', 2), ('lemon', 4), ('bias', 8)],
-         'neg': [('tree', -6)],
-         'neg_remaining': 10})
-    assert w_spans == {
-        'analyzer': 'word',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        FeatureWeights(
+            pos=[('see', 2), ('lemon', 4), ('bias', 8)],
+            neg=[('tree', -6)],
+            neg_remaining=10
+        ))
+    assert w_spans == WeightedSpans(
+        analyzer='word',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 2),
             ('lemon', [(17, 22)], 4),
             ('tree', [(23, 27)], -6)],
-        'other': {
-            'pos': [('bias', 8), (hl_in_text, 0)],
-            'neg': [],
-            'neg_remaining': 10}}
+        other=FeatureWeights(
+            pos=[('bias', 8), (hl_in_text, 0)],
+            neg=[],
+            neg_remaining=10,
+        ))
 
 
 def test_weighted_spans_word_bigrams():
@@ -35,20 +39,21 @@ def test_weighted_spans_word_bigrams():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {'pos': [('see', 2), ('leaning lemon', 5), ('lemon tree', 8)],
-         'neg': [('tree', -6)]})
-    assert w_spans == {
-        'analyzer': 'word',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        FeatureWeights(
+            pos=[('see', 2), ('leaning lemon', 5), ('lemon tree', 8)],
+            neg=[('tree', -6)]))
+    assert w_spans == WeightedSpans(
+        analyzer='word',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 2),
             ('tree', [(23, 27)], -6),
             ('leaning lemon', [(9, 16), (17, 22)], 5),
             ('lemon tree', [(17, 22), (23, 27)], 8)],
-        'other': {
-            'pos': [(hl_in_text, 9)],
-            'neg': [],
-        }}
+        other=FeatureWeights(
+            pos=[(hl_in_text, 9)],
+            neg=[],
+        ))
 
 
 def test_weighted_spans_word_stopwords():
@@ -57,18 +62,19 @@ def test_weighted_spans_word_stopwords():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {'pos': [('see', 2), ('lemon', 5), ('bias', 8)],
-         'neg': [('tree', -6)]})
-    assert w_spans == {
-        'analyzer': 'word',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        FeatureWeights(
+            pos=[('see', 2), ('lemon', 5), ('bias', 8)],
+            neg=[('tree', -6)]))
+    assert w_spans == WeightedSpans(
+        analyzer='word',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('lemon', [(17, 22)], 5),
             ('tree', [(23, 27)], -6)],
-        'other': {
-            'pos': [('bias', 8), ('see', 2)],
-            'neg': [(hl_in_text, -1)],
-        }}
+        other=FeatureWeights(
+            pos=[('bias', 8), ('see', 2)],
+            neg=[(hl_in_text, -1)],
+        ))
 
 
 def test_weighted_spans_char():
@@ -77,32 +83,33 @@ def test_weighted_spans_char():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {'pos': [('see', 2), ('a le', 5), ('on ', 8)],
-         'neg': [('lem', -6)]})
-    assert w_spans == {
-        'analyzer': 'char',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        FeatureWeights(
+            pos=[('see', 2), ('a le', 5), ('on ', 8)],
+            neg=[('lem', -6)]))
+    assert w_spans == WeightedSpans(
+        analyzer='char',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 2),
             ('lem', [(17, 20)], -6),
             ('on ', [(20, 23)], 8),
             ('a le', [(7, 11)], 5)],
-        'other': {
-            'pos': [(hl_in_text, 9)],
-            'neg': [],
-        }}
+        other=FeatureWeights(
+            pos=[(hl_in_text, 9)],
+            neg=[],
+        ))
 
 
 def test_no_weighted_spans():
     doc = 'I see: a leaning lemon tree'
     vec = CountVectorizer(analyzer='char', ngram_range=(3, 4))
     vec.fit([doc])
-    w_spans = get_weighted_spans(doc, vec, {'pos': [], 'neg': []})
-    assert w_spans == {
-        'analyzer': 'char',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [],
-        'other': {'pos': [], 'neg': []}}
+    w_spans = get_weighted_spans(doc, vec, FeatureWeights(pos=[], neg=[]))
+    assert w_spans == WeightedSpans(
+        analyzer='char',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[],
+        other=FeatureWeights(pos=[], neg=[]))
 
 
 def test_weighted_spans_char_wb():
@@ -111,20 +118,21 @@ def test_weighted_spans_char_wb():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {'pos': [('see', 2), ('a le', 5), ('on ', 8)],
-         'neg': [('lem', -6), (' lem', -4)]})
-    assert w_spans == {
-        'analyzer': 'char_wb',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        FeatureWeights(
+            pos=[('see', 2), ('a le', 5), ('on ', 8)],
+            neg=[('lem', -6), (' lem', -4)]))
+    assert w_spans == WeightedSpans(
+        analyzer='char_wb',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 2),
             ('lem', [(17, 20)], -6),
             ('on ', [(20, 23)], 8),
             (' lem', [(16, 20)], -4)],
-        'other': {
-            'pos': [('a le', 5), (hl_in_text, 0)],
-            'neg': [],
-        }}
+        other=FeatureWeights(
+            pos=[('a le', 5), (hl_in_text, 0)],
+            neg=[],
+        ))
 
 
 def test_unhashed_features_other():
@@ -137,26 +145,26 @@ def test_unhashed_features_other():
     vec.fit([doc])
     w_spans = get_weighted_spans(
         doc, vec,
-        {
-            'pos': [
+        FeatureWeights(
+            pos=[
                 ([{'name': 'foo', 'sign': 1}, {'name': 'see', 'sign': -1}], 2),
                 ([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
-            'neg': [
+            neg=[
                 ([{'name': 'ree', 'sign': 1}, {'name': 'tre', 'sign': 1}], -4),
             ],
-        })
-    assert w_spans == {
-        'analyzer': 'char',
-        'document': 'i see: a leaning lemon tree',
-        'weighted_spans': [
+        ))
+    assert w_spans == WeightedSpans(
+        analyzer='char',
+        document='i see: a leaning lemon tree',
+        weighted_spans=[
             ('see', [(2, 5)], 2),
             ('tre', [(23, 26)], -4),
             ('ree', [(24, 27)], -4),
             ],
-        'other': {
-            'pos': [
+        other=FeatureWeights(
+            pos=[
                 ([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
-            'neg': [(hl_in_text, -2)],
-        }}
+            neg=[(hl_in_text, -2)],
+        ))

--- a/tests/test_sklearn_treeinspect.py
+++ b/tests/test_sklearn_treeinspect.py
@@ -4,14 +4,14 @@ from __future__ import absolute_import
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from eli5.formatters.trees import tree2text
-from eli5.sklearn.treeinspect import tree2dict
+from eli5.sklearn.treeinspect import get_tree_info
 
 
 def test_tree2dict():
     X = [[1, 1], [0, 2], [0, 3], [1, 3], [2, 3], [0, 4]]
     y = [0, 0, 0, 1, 1, 1]
     clf = DecisionTreeClassifier(random_state=42).fit(X, y)
-    text = tree2text(tree2dict(clf))
+    text = tree2text(get_tree_info(clf))
     print(text)
     expected = """
 x1 <= 2.500  (33.3%)  ---> [1.000, 0.000]
@@ -24,7 +24,7 @@ x1 > 2.500  (66.7%)
     assert text == expected
 
     # check it with feature_names
-    text = tree2text(tree2dict(clf, feature_names=['x', 'y']))
+    text = tree2text(get_tree_info(clf, feature_names=['x', 'y']))
     print(text)
     expected = """
 y <= 2.500  (33.3%)  ---> [1.000, 0.000]


### PR DESCRIPTION
This way result of explain_weights and explain_prediction is shown with html formatter in IPython. Almost all styles are inline anyway, but there is a tiny bit that is included with every output. I think this is not a problem at the moment, but I don't know how to solve it in general without awful hacks.