### PR TITLE
Format explanation as html in the notebook

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -15,6 +15,10 @@ class Explanation(object):
     feature_importances = attr.ib(default=None)  # type: FeatureWeights
     decision_tree = attr.ib(default=None)  # type: TreeInfo
 
+    def _repr_html_(self):
+        from eli5.formatters import format_as_html, fields
+        return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
+
 
 @attr.s
 class TargetExplanation(object):


### PR DESCRIPTION
Showing only weights in the most compact form by default.

This is #47 re-done: I could not figure how to rebase the ipython branch against attrs (that was rebased and maybe also squashed) without running into a ton of conflicts, so I just cherry-picked required commits, sorry for the mess :)