### PR TITLE
Always show errors, add a custom style

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -17,7 +17,11 @@ class Explanation(object):
 
     def _repr_html_(self):
         from eli5.formatters import format_as_html, fields
-        return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
+        if self.targets or self.feature_importances or self.decision_tree:
+            show = fields.WEIGHTS
+        else:
+            show = fields.ALL
+        return format_as_html(self, force_weights=False, show=show)
 
 
 @attr.s

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -9,6 +9,7 @@ import attr
 class Explanation(object):
     estimator = attr.ib()  # type: str
     description = attr.ib(default=None)  # type: str
+    error = attr.ib(default=None)  # type: str
     method = attr.ib(default=None)  # type: str
     targets = attr.ib(default=None)  # type: List[TargetExplanation]
     is_regression = attr.ib(default=False)  # type: bool
@@ -17,11 +18,7 @@ class Explanation(object):
 
     def _repr_html_(self):
         from eli5.formatters import format_as_html, fields
-        if self.targets or self.feature_importances or self.decision_tree:
-            show = fields.WEIGHTS
-        else:
-            show = fields.ALL
-        return format_as_html(self, force_weights=False, show=show)
+        return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
 
 
 @attr.s

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -22,6 +22,9 @@ def format_as_text(expl, show=fields.ALL):
     if 'description' in show and expl.description:
         lines.append(expl.description)
 
+    if expl.error:  # always shown
+        lines.append('Error: {}'.format(expl.error))
+
     if 'targets' in show and expl.targets:
         lines.extend(_format_weights(expl))
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -50,7 +50,7 @@ def explain_prediction_sklearn(estimator, doc, vec=None, top=_TOP, target_names=
     """ Return an explanation of a scikit-learn estimator """
     return Explanation(
         estimator=repr(estimator),
-        description="Error: estimator %r is not supported" % estimator,
+        error="estimator %r is not supported" % estimator,
     )
 
 

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -101,7 +101,7 @@ def explain_weights_sklearn(estimator, vec=None, top=_TOP, target_names=None,
     """ Return an explanation of an estimator """
     return Explanation(
         estimator=repr(estimator),
-        description="Error: estimator %r is not supported" % estimator,
+        error="estimator %r is not supported" % estimator,
     )
 
 

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -47,5 +47,10 @@
         <pre>{{ expl.decision_tree|format_decision_tree }}</pre>
     {% endif %}
 
-
 {% endfor %}
+
+{% if expl.error %}
+    <div style="background-color: #fdd; padding: 0.5em;">
+        Error: {{ expl.error }}
+    </div>
+{% endif %}

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@
 
 from sklearn.linear_model import LinearRegression
 from sklearn.tree import DecisionTreeRegressor
+from sklearn.base import BaseEstimator
 
 from eli5.sklearn import explain_weights_sklearn
 
@@ -16,12 +17,8 @@ def test_repr_html(boston_train):
     assert 'BIAS' in html
 
 
-class MyNotSupportedRegressor(object):
-    pass
-
-
 def test_repr_html_error():
-    reg = MyNotSupportedRegressor()
+    reg = BaseEstimator()
     res = explain_weights_sklearn(reg)
     html = res._repr_html_()
-    assert 'MyNotSupportedRegressor' in html
+    assert 'BaseEstimator' in html

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from sklearn.linear_model import LinearRegression
+from sklearn.tree import DecisionTreeRegressor
+
+from eli5.sklearn import explain_weights_sklearn
+
+
+def test_repr_html(boston_train):
+    X, y, feature_names = boston_train
+    reg = LinearRegression()
+    reg.fit(X, y)
+    res = explain_weights_sklearn(reg)
+    html = res._repr_html_()
+    assert 'LinearRegression' not in html
+    assert 'BIAS' in html
+
+
+class MyNotSupportedRegressor(object):
+    pass
+
+
+def test_repr_html_error():
+    reg = MyNotSupportedRegressor()
+    res = explain_weights_sklearn(reg)
+    html = res._repr_html_()
+    assert 'MyNotSupportedRegressor' in html

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -229,7 +229,10 @@ def test_unsupported():
     vec = CountVectorizer()
     clf = BaseEstimator()
     res = explain_weights(clf, vec=vec)
-    assert 'Error' in res.description
+    assert 'BaseEstimator' in res.error
+    for expl in format_as_all(res, clf):
+        assert 'Error' in expl
+        assert 'BaseEstimator' in expl
 
 
 @pytest.mark.parametrize(['clf'], [

--- a/tests/test_sklearn_vectorizers.py
+++ b/tests/test_sklearn_vectorizers.py
@@ -111,7 +111,10 @@ def test_unsupported():
     vec = CountVectorizer()
     clf = BaseEstimator()
     res = explain_prediction(clf, 'hello, world', vec=vec)
-    assert 'Error' in res.description
+    assert 'BaseEstimator' in res.error
+    for expl in format_as_all(res, clf):
+        assert 'Error' in expl
+        assert 'BaseEstimator' in expl
 
 
 def test_explain_regression_hashing_vectorizer(newsgroups_train_binary):


### PR DESCRIPTION
Fixes #52 

Now errors are always shown (and live in a separate field), and highlighted in html as error (using the same color that Jupyter Notebook currently uses):
![2016-11-03 12 34 56](https://cloud.githubusercontent.com/assets/424613/19961151/0c9c4872-a1c2-11e6-9a42-c62d244ea279.png)
