### PR TITLE
remove workarounds for scikit-learn < 0.18. Fixed GH-50.

### DIFF
--- a/eli5/lime/lime.py
+++ b/eli5/lime/lime.py
@@ -57,10 +57,7 @@ import numpy as np
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
-try:
-    from sklearn.model_selection import train_test_split
-except ImportError:  # sklearn < 0.18
-    from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 from eli5.lime import textutils
 from eli5.lime.samplers import MaskingTextSampler

--- a/eli5/lime/samplers.py
+++ b/eli5/lime/samplers.py
@@ -10,10 +10,7 @@ from eli5.lime.utils import rbf
 from sklearn.base import BaseEstimator, clone
 from sklearn.neighbors import KernelDensity
 from sklearn.metrics import pairwise_distances
-try:
-    from sklearn.model_selection import GridSearchCV, KFold
-except ImportError:  # scikit-learn < 0.18
-    from sklearn.cross_validation import GridSearchCV, KFold
+from sklearn.model_selection import GridSearchCV, KFold
 
 from .textutils import generate_samples, DEFAULT_TOKEN_PATTERN
 

--- a/eli5/sklearn/treeinspect.py
+++ b/eli5/sklearn/treeinspect.py
@@ -30,15 +30,8 @@ def get_tree_info(decision_tree, feature_names=None, **export_graphviz_kwargs):
 
 
 def tree2dot(decision_tree, **export_graphviz_kwargs):
-    # use temp files to support scikit-learn < 0.18
-    path = mkdtemp()
-    try:
-        tmpfile = os.path.join(path, 'tree.dot')
-        export_graphviz(decision_tree, tmpfile, **export_graphviz_kwargs)
-        with open(tmpfile, 'rb') as f:
-            return f.read().decode('utf8')
-    finally:
-        shutil.rmtree(path)
+    return export_graphviz(decision_tree, out_file=None,
+                           **export_graphviz_kwargs)
 
 
 def _get_root_node_info(decision_tree, feature_names=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy >= 1.9.0
 singledispatch >= 3.4.0.3
-scikit-learn >= 0.17
+scikit-learn >= 0.18
+attrs
+jinja2


### PR DESCRIPTION
Some of these workarounds didn't work anyways.