### PR TITLE
TST check types on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - TOXENV=py27
     - TOXENV=py35
     - TOXENV=py35-nodeps
+    - TOXENV=mypy
 
 addons:
     apt:

--- a/eli5/lime/textutils.py
+++ b/eli5/lime/textutils.py
@@ -4,7 +4,7 @@ Utilities for text generation.
 """
 from __future__ import absolute_import
 import re
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 import numpy as np
 from sklearn.utils import check_random_state
@@ -15,7 +15,7 @@ DEFAULT_TOKEN_PATTERN = r'(?u)\b\w+\b'
 def generate_samples(text, n_samples=500, bow=True,
                      token_pattern=DEFAULT_TOKEN_PATTERN,
                      random_state=None):
-    # type: (str, int, bool, str) -> Tuple[List[str], np.ndarray]
+    # type: (str, int, bool, str, Any) -> Tuple[List[str], np.ndarray]
     """
     Return ``n_samples`` changed versions of text (with some words removed),
     along with distances between the original text and a generated

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -45,8 +45,9 @@ _TOP = 20
 
 @explain_prediction.register(BaseEstimator)
 @singledispatch
-def explain_prediction_sklearn(estimator, doc, vec=None, top=_TOP, target_names=None,
-                               feature_names=None, vectorized=False):
+def explain_prediction_sklearn(estimator, doc, vec=None, top=_TOP,
+                               target_names=None, feature_names=None,
+                               vectorized=False):
     """ Return an explanation of a scikit-learn estimator """
     return Explanation(
         estimator=repr(estimator),

--- a/eli5/sklearn/unhashing.py
+++ b/eli5/sklearn/unhashing.py
@@ -4,10 +4,9 @@ Utilities to reverse transformation done by FeatureHasher or HashingVectorizer.
 """
 from __future__ import absolute_import
 
-from functools import partial
 from collections import defaultdict, Counter
 from itertools import chain
-from typing import List, Iterable
+from typing import List, Iterable, Any
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -40,7 +39,7 @@ class InvertableHashingVectorizer(BaseEstimator, TransformerMixin):
     """
     def __init__(self, vec,
                  unkn_template="FEATURE[%d]"):
-        # type: (HashingVectorizer, str, bool) -> None
+        # type: (HashingVectorizer, str) -> None
         self.vec = vec
         self.unkn_template = unkn_template
         self.unhasher = FeatureUnhasher(
@@ -102,7 +101,7 @@ class FeatureUnhasher(BaseEstimator):
     Class for recovering a mapping used by FeatureHasher.
     """
     def __init__(self, hasher, unkn_template="FEATURE[%d]"):
-        # type: (FeatureHasher) -> None
+        # type: (FeatureHasher, str) -> None
         if hasher.input_type != 'string':
             raise ValueError("FeatureUnhasher only supports hashers with "
                              "input_type 'string', got %r." % hasher.input_type)
@@ -110,17 +109,17 @@ class FeatureUnhasher(BaseEstimator):
         self.n_features = self.hasher.n_features
         self.unkn_template = unkn_template
         self._attributes_dirty = True
-        self._term_counts = Counter()
+        self._term_counts = Counter()  # type: Counter
 
     def fit(self, X, y=None):
-        # type: (Iterable[str], None) -> FeatureUnhasher
+        # type: (Iterable[str], Any) -> FeatureUnhasher
         self._term_counts.clear()
         self.partial_fit(X, y)
         self.recalculate_attributes(force=True)
         return self
 
     def partial_fit(self, X, y=None):
-        # type: (Iterable[str], None) -> FeatureUnhasher
+        # type: (Iterable[str], Any) -> FeatureUnhasher
         self._term_counts.update(X)
         self._attributes_dirty = True
         return self

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 ; under all supported Python interpreters
 
 [tox]
-envlist = py27,py34,py35,py35-nodeps
+envlist = py27,py34,py35,py35-nodeps,mypy
 
 [testenv]
 deps=
@@ -17,7 +17,6 @@ commands=
     ; to install lightning numpy must be installed first
     pip install "sklearn-contrib-lightning >= 0.4"
 
-    pip install -r ./requirements-test.txt
     pip install -e .
     py.test --doctest-modules --cov=eli5 --cov-report=html --cov-report=term {posargs: eli5 tests}
 
@@ -25,7 +24,13 @@ commands=
 [testenv:py35-nodeps]
 commands=
     ; without lightning as it is optional
-    pip install -r ./requirements-test.txt
     pip install -e .
     py.test --ignore eli5/lightning.py --doctest-modules --cov=eli5 --cov-report=html --cov-report=term {posargs: eli5 tests}
 
+[testenv:mypy]
+basepython=python3.5
+deps=
+    {[testenv]deps}
+    mypy-lang
+commands=
+    mypy --silent-imports eli5


### PR DESCRIPTION
Currently not a lot of things is checked because `mypy --silent-imports --check-untyped-defs eli5` fails with multiple errors. There is a lot of errors like this when `--check-untyped-defs` option is enabled:

```
eli5/_feature_weights.py: note: In function "get_top_features":
eli5/_feature_weights.py:41: error: Unexpected keyword argument "pos" for "FeatureWeights"
eli5/_feature_weights.py:41: error: Unexpected keyword argument "neg" for "FeatureWeights"
eli5/_feature_weights.py:41: error: Unexpected keyword argument "pos_remaining" for "FeatureWeights"
eli5/_feature_weights.py:41: error: Unexpected keyword argument "neg_remaining" for "FeatureWeights"
```

but at least some checks are good; at least it will keep type declarations in sync (they were broken).