### PR TITLE
Highlight spaces conditionally

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -23,6 +23,7 @@ class Explanation(object):
                  targets=None,  # type: List[TargetExplanation]
                  feature_importances=None,  # type: FeatureWeights
                  decision_tree=None,  # type: TreeInfo
+                 highlight_spaces=None,
                  ):
         self.estimator = estimator
         self.description = description
@@ -32,6 +33,7 @@ class Explanation(object):
         self.targets = targets
         self.feature_importances = feature_importances
         self.decision_tree = decision_tree
+        self.highlight_spaces = highlight_spaces
 
     def _repr_html_(self):
         from eli5.formatters import format_as_html, fields

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -36,7 +36,8 @@ class Explanation(object):
         self.highlight_spaces = highlight_spaces
 
     def _repr_html_(self):
-        from eli5.formatters import format_as_html, fields
+        from eli5.formatters import fields
+        from eli5.formatters.html import format_as_html
         return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
 
 

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -7,7 +7,7 @@ import numpy as np
 from jinja2 import Environment, PackageLoader
 
 from eli5 import _graphviz
-from .utils import format_signed, replace_spaces
+from .utils import format_signed, replace_spaces, should_highlight_spaces
 from . import fields
 from .features import FormattedFeatureName
 from .trees import tree2text
@@ -23,13 +23,13 @@ template_env.filters.update(dict(
         _remaining_weight_color(ws, w_range, pos_neg),
     weight_range=lambda w: _weight_range(w),
     fi_weight_range=lambda w: max([abs(x[1]) for x in w] or [0]),
-    format_feature=lambda f, w: _format_feature(f, w),
+    format_feature=lambda f, w, hl: _format_feature(f, w, hl_spaces=hl),
     format_decision_tree=lambda tree: _format_decision_tree(tree),
 ))
 
 
 def format_as_html(explanation, include_styles=True, force_weights=True,
-                   show=fields.ALL, preserve_density=None):
+                   show=fields.ALL, preserve_density=None, higlight_spaces=None):
     """ Format explanation as html.
     Most styles are inline, but some are included separately in <style> tag,
     you can omit them by passing ``include_styles=False`` and call
@@ -39,6 +39,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     in the document.
     """
     template = template_env.get_template('explain.html')
+    if higlight_spaces is None:
+        higlight_spaces = should_highlight_spaces(explanation)
 
     return template.render(
         include_styles=include_styles,
@@ -50,7 +52,9 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none;',
         td2_styles='padding: 0 0.5em 0 0.5em; text-align: left; border: none;',
         show=show,
-        expl=explanation)
+        expl=explanation,
+        hl_spaces=higlight_spaces,
+    )
 
 
 def format_html_styles():
@@ -160,7 +164,7 @@ def _remaining_weight_color(ws, weight_range, pos_neg):
     return _weight_color(weight, weight_range)
 
 
-def _format_unhashed_feature(feature, weight):
+def _format_unhashed_feature(feature, weight, hl_spaces):
     """ Format unhashed feature: show first (most probable) candidate,
     display other candidates in title attribute.
     """
@@ -168,26 +172,30 @@ def _format_unhashed_feature(feature, weight):
         return ''
     else:
         first, rest = feature[0], feature[1:]
-        html = format_signed(first, lambda x: _format_single_feature(x, weight))
+        html = format_signed(
+            first, lambda x: _format_single_feature(x, weight, hl_spaces))
         if rest:
             html += ' <span title="{}">&hellip;</span>'.format(
                 '\n'.join(html_escape(format_signed(f)) for f in rest))
         return html
 
 
-def _format_feature(feature, weight):
+def _format_feature(feature, weight, hl_spaces):
     """ Format any feature.
     """
     if isinstance(feature, FormattedFeatureName):
         return feature.format()
     elif (isinstance(feature, list) and
             all('name' in x and 'sign' in x for x in feature)):
-        return _format_unhashed_feature(feature, weight)
+        return _format_unhashed_feature(feature, weight, hl_spaces=hl_spaces)
     else:
-        return _format_single_feature(feature, weight)
+        return _format_single_feature(feature, weight, hl_spaces=hl_spaces)
 
 
-def _format_single_feature(feature, weight):
+def _format_single_feature(feature, weight, hl_spaces):
+    feature = html_escape(feature)
+    if not hl_spaces:
+        return feature
 
     def replacer(n_spaces, side):
         m = '0.1em'
@@ -202,7 +210,7 @@ def _format_single_feature(feature, weight):
                   '{} space symbols'.format(n_spaces),
             spaces='&emsp;' * n_spaces)
 
-    return replace_spaces(html_escape(feature), replacer)
+    return replace_spaces(feature, replacer)
 
 
 def _format_decision_tree(treedict):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -29,7 +29,7 @@ template_env.filters.update(dict(
 
 
 def format_as_html(explanation, include_styles=True, force_weights=True,
-                   show=fields.ALL, preserve_density=None, higlight_spaces=None):
+                   show=fields.ALL, preserve_density=None, highlight_spaces=None):
     """ Format explanation as html.
     Most styles are inline, but some are included separately in <style> tag,
     you can omit them by passing ``include_styles=False`` and call
@@ -39,8 +39,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     in the document.
     """
     template = template_env.get_template('explain.html')
-    if higlight_spaces is None:
-        higlight_spaces = should_highlight_spaces(explanation)
+    if highlight_spaces is None:
+        highlight_spaces = should_highlight_spaces(explanation)
 
     return template.render(
         include_styles=include_styles,
@@ -53,7 +53,7 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         td2_styles='padding: 0 0.5em 0 0.5em; text-align: left; border: none;',
         show=show,
         expl=explanation,
-        hl_spaces=higlight_spaces,
+        hl_spaces=highlight_spaces,
     )
 
 

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -37,6 +37,10 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     With ``force_weights=False``, weights will not be displayed in a table for
     predictions where it is possible to show feature weights highlighted
     in the document.
+    If ``highlight_spaces`` is None (default), spaces will be highlighted in
+    feature names only if there are any spaces at the start or at the end of the
+    feature. Setting it to True forces space highlighting, and setting it to False
+    turns it off.
     """
     template = template_env.get_template('explain.html')
     if highlight_spaces is None:

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -15,6 +15,12 @@ _SPACE = '_' if six.PY2 else '░'
 
 
 def format_as_text(expl, show=fields.ALL, highlight_spaces=None):
+    """ Format explanation as text.
+    If ``highlight_spaces`` is None (default), spaces will be highlighted in
+    feature names only if there are any spaces at the start or at the end of the
+    feature. Setting it to True forces space highlighting, and setting it to False
+    turns it off.
+    """
     lines = []  # type: List[str]
 
     if highlight_spaces is None:

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -62,6 +62,6 @@ def should_highlight_spaces(explanation):
 
 def _has_invisible_spaces(name):
     # type: (Union[str, Dict]) -> bool
-    if isinstance(name, dict):
-        name = name['name']
+    if isinstance(name, list):
+        return any(_has_invisible_spaces(n['name']) for n in name)
     return name.startswith(' ') or name.endswith(' ')

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -1,4 +1,7 @@
 import re
+from typing import Union
+
+from eli5.base import Explanation
 
 
 def replace_spaces(s, replacer):
@@ -61,7 +64,7 @@ def should_highlight_spaces(explanation):
 
 
 def _has_invisible_spaces(name):
-    # type: (Union[str, Dict]) -> bool
+    # type: (Union[str, List[Dict]]) -> bool
     if isinstance(name, list):
         return any(_has_invisible_spaces(n['name']) for n in name)
     return name.startswith(' ') or name.endswith(' ')

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -32,7 +32,7 @@
                             {{ "%0.4f"|format(w) }} &plusmn; {{ "%0.4f"|format(2 * std) }}
                         </td>
                         <td style="{{ td2_styles }}">
-                            {{ name|format_feature(w) }}
+                            {{ name|format_feature(w, hl_spaces) }}
                         </td>
                     </tr>
                 {% endfor %}

--- a/eli5/templates/weights_table_row.html
+++ b/eli5/templates/weights_table_row.html
@@ -3,6 +3,6 @@
         {{ "%+.3f"|format(coef) }}
     </td>
     <td style="{{ td2_styles }}">
-        {{ name|format_feature(coef) }}
+        {{ name|format_feature(coef, hl_spaces) }}
     </td>
 </tr>

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import re
 
+import pytest
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from eli5.sklearn import explain_weights_sklearn, explain_prediction_sklearn
 from eli5.formatters import fields
+from eli5.formatters.text import _SPACE
 from .utils import format_as_all, get_all_features
 
 
@@ -50,3 +53,43 @@ def test_formatter_order(boston_train):
     assert neg_weights['x10'] < neg_weights['x12']
     for expl in [expl_text, expl_html]:
         assert expl.find('x10') > expl.find('x12')
+
+
+@pytest.mark.parametrize(
+    ['hl_spaces', 'add_invisible_spaces'],
+    [[hl, add] for hl in [None, True, False] for add in [True, False]])
+def test_highlight_spaces(boston_train, hl_spaces, add_invisible_spaces):
+    reg = LinearRegression()
+    X, y, feature_names = boston_train
+    # last is left unmodified to check that we are doing "any", not "all"
+    modified_feature_names = \
+        [('{} ' if add_invisible_spaces else 'A {}').format(name)
+        for name in feature_names[:-1]] + [feature_names[-1]]
+    reg.fit(X, y)
+    res = explain_weights_sklearn(
+        reg, feature_names=modified_feature_names, top=len(feature_names) + 1)
+    expls = format_as_all(res, reg, highlight_spaces=hl_spaces)
+    for is_html, expl in enumerate(expls):
+        print(expl)
+        if hl_spaces == False or (hl_spaces is None and not add_invisible_spaces):
+            for f in modified_feature_names:
+                assert f in expl
+        else:
+            if not add_invisible_spaces:
+                assert hl_spaces
+            for f in modified_feature_names[:-1]:
+                assert f not in expl
+            for f in feature_names[:-1]:
+                if is_html:
+                    if add_invisible_spaces:
+                        assert re.search(
+                            f + '<span.*title="A space symbol"', expl)
+                    else:
+                        assert re.search(
+                            'A<span.*title="A space symbol".*>' + f, expl)
+                else:
+                    if add_invisible_spaces:
+                        assert (f + _SPACE) in expl
+                    else:
+                        assert ('A' + _SPACE + f) in expl
+

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -12,31 +12,43 @@ def test_render_styles():
     assert styles.strip().startswith('<style')
 
 
+def format_unhashed_feature(feature, weight=1, hl_spaces=True):
+    return _format_unhashed_feature(feature, weight=weight, hl_spaces=hl_spaces)
+
+
+def format_feature(feature, weight=1, hl_spaces=True):
+    return _format_feature(feature, weight=weight, hl_spaces=hl_spaces)
+
+
+def format_single_feature(feature, weight=1, hl_spaces=True):
+    return _format_single_feature(feature, weight=weight, hl_spaces=hl_spaces)
+
+
 def test_format_unhashed_feature():
-    assert _format_unhashed_feature([], 1) == ''
-    assert _format_unhashed_feature([{'name': 'foo', 'sign': 1}], 1) == 'foo'
-    assert _format_unhashed_feature([{'name': 'foo', 'sign': -1}], 1) == '(-)foo'
-    assert _format_unhashed_feature([
+    assert format_unhashed_feature([]) == ''
+    assert format_unhashed_feature([{'name': 'foo', 'sign': 1}]) == 'foo'
+    assert format_unhashed_feature([{'name': 'foo', 'sign': -1}]) == '(-)foo'
+    assert format_unhashed_feature([
         {'name': 'foo', 'sign': 1},
         {'name': 'bar', 'sign': -1}
-        ], 1) == 'foo <span title="(-)bar">&hellip;</span>'
-    assert _format_unhashed_feature([
+        ]) == 'foo <span title="(-)bar">&hellip;</span>'
+    assert format_unhashed_feature([
         {'name': 'foo', 'sign': 1},
         {'name': 'bar', 'sign': -1},
         {'name': 'boo', 'sign': 1},
-    ], 1) == 'foo <span title="(-)bar\nboo">&hellip;</span>'
+        ]) == 'foo <span title="(-)bar\nboo">&hellip;</span>'
 
 
 def test_format_formatted_feature():
-    assert _format_feature(FormattedFeatureName('a b'), 1) == 'a b'
-    assert _format_feature('a b', 1) != 'a b'
-    assert _format_feature('a b', 1) == _format_single_feature('a b', 1)
+    assert format_feature(FormattedFeatureName('a b')) == 'a b'
+    assert format_feature('a b') != 'a b'
+    assert format_feature('a b') == format_single_feature('a b')
 
 
 def test_format_single_feature():
-    assert _format_single_feature('a', 1) == 'a'
-    assert _format_single_feature('<>', 1) == '&lt;&gt;'
-    assert _format_single_feature('aa bb', 1) == (
+    assert format_single_feature('a') == 'a'
+    assert format_single_feature('<>') == '&lt;&gt;'
+    assert format_single_feature('aa bb') == (
         'aa'
         '<span '
         'style="background-color: hsl(120, 80%, 70%); margin: 0 0.1em 0 0.1em" '
@@ -44,7 +56,7 @@ def test_format_single_feature():
         '&emsp;'
         '</span>'
         'bb')
-    assert _format_single_feature('  aa bb ', -1) == (
+    assert format_single_feature('  aa bb ', weight=-1) == (
         '<span '
         'style="background-color: hsl(0, 80%, 70%); margin: 0 0.1em 0 0" '
         'title="2 space symbols">'

--- a/tests/test_formatters_text.py
+++ b/tests/test_formatters_text.py
@@ -4,17 +4,21 @@ from eli5.formatters import FormattedFeatureName
 from eli5.formatters.text import _format_feature, _SPACE
 
 
+def format_feature(feature, hl_spaces=True):
+    return _format_feature(feature, hl_spaces=hl_spaces)
+
+
 def test_format_formatted_feature():
-    assert _format_feature(FormattedFeatureName('a b')) == 'a b'
-    assert _format_feature('a b') == 'a{}b'.format(_SPACE)
+    assert format_feature(FormattedFeatureName('a b')) == 'a b'
+    assert format_feature('a b') == 'a{}b'.format(_SPACE)
 
 
 def test_format_unhashed_feature():
-    assert _format_feature([]) == ''
-    assert _format_feature([{'name': 'foo', 'sign': 1}]) == 'foo'
-    assert _format_feature([{'name': ' foo', 'sign': -1}]) == \
+    assert format_feature([]) == ''
+    assert format_feature([{'name': 'foo', 'sign': 1}]) == 'foo'
+    assert format_feature([{'name': ' foo', 'sign': -1}]) == \
         '(-){}foo'.format(_SPACE)
-    assert _format_feature([
+    assert format_feature([
         {'name': 'foo', 'sign': 1},
         {'name': 'bar', 'sign': -1}
-    ]) == 'foo | (-)bar'
+        ]) == 'foo | (-)bar'


### PR DESCRIPTION
This should fix a part of #38 - now we'll only highlight spaces if ``highlight_spaces`` is set to True, or if there are any "invisible" spaces in the explanation.
It is also possible to force space highlighting if we are passed a text vectorizer in explain_weights or explain_prediction - do you think it's worth doing @kmike ?