### PR TITLE
Require tabulate>=0.7.7 due to showindex use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'six',
         'typing',
         'graphviz',
-        'tabulate',
+        'tabulate>=0.7.7',
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
"showindex" is not supported in 0.7.5, and 0.7.7 was just released (2 days ago). I noticed because I happened to have 0.7.5 already installed, and tests failed with ``TypeError: tabulate() got an unexpected keyword argument 'showindex'``