### PR TITLE
vertical-align: top for tds wrapping tables

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -61,7 +61,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         td2_styles='padding: 0 0.5em 0 0.5em; text-align: left; border: none;',
         horizontal_layout_table_styles=
         'border-collapse: collapse; border: none;',
-        horizontal_layout_td_styles='padding: 0px; border: 1px solid black;',
+        horizontal_layout_td_styles=
+        'padding: 0px; border: 1px solid black; vertical-align: top;',
         tddm_header_styles='text-align: center; padding: 0.5em; '
                            'border: none; border-bottom: 1px solid black;',
         show=show,


### PR DESCRIPTION
In the autologin notebook https://github.com/TeamHG-Memex/autopager/blob/master/notebooks/Training.ipynb I noticed a problem with alignment when there is a different number of features for different targets:
![2016-11-10 13 00 33](https://cloud.githubusercontent.com/assets/424613/20172357/c405804a-a745-11e6-99f2-2e8f02f82ba5.png)
This fixes the problem:
![2016-11-10 13 00 58](https://cloud.githubusercontent.com/assets/424613/20172362/c706b502-a745-11e6-9f09-2a0fffd02ae9.png)
