### PR TITLE
Add feature filtering in explain_weights

### DIFF
--- a/eli5/_feature_names.py
+++ b/eli5/_feature_names.py
@@ -63,8 +63,7 @@ class FeatureNames(object):
             indexed_names = six.iteritems(self.feature_names)
         elif self.feature_names is None:
             indexed_names = []
-        else:
-            assert False, 'should be checked in __init__'
+        assert indexed_names is not None
         if isinstance(feature_re, six.string_types):
             filter_fn = lambda x: re.search(feature_re, x, re.U)
         else:
@@ -74,7 +73,6 @@ class FeatureNames(object):
                 indices.append(idx)
                 filtered_feature_names.append(name)
         return (
-
             FeatureNames(
                 filtered_feature_names,
                 bias_name=self.bias_name,

--- a/eli5/_feature_names.py
+++ b/eli5/_feature_names.py
@@ -1,0 +1,74 @@
+import re
+
+import numpy as np
+
+
+class FeatureNames(object):
+    """
+    A list-like object with feature names. It allows
+    feature names for unknown features to be generated using
+    a provided template, and to avoid making copies of large objects
+    in get_feature_names.
+    """
+    def __init__(self, feature_names=None, bias_name=None,
+                 unkn_template=None, n_features=None):
+        assert (feature_names is not None or
+                (unkn_template is not None and n_features))
+        self.feature_names = feature_names
+        self.unkn_template = unkn_template
+        self.n_features = n_features or len(feature_names)
+        self.bias_name = bias_name
+
+    def __repr__(self):
+        return '<FeatureNames: {} features {} bias>'.format(
+            self.n_features, 'with' if self.has_bias else 'without')
+
+    def __len__(self):
+        return self.n_features + int(self.has_bias)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, np.ndarray):
+            return [self[i] for i in idx]
+        n = len(self)
+        if self.has_bias and idx == n - 1:
+            return self.bias_name
+        if 0 <= idx < n:
+            try:
+                return self.feature_names[idx]
+            except (TypeError, KeyError, IndexError):
+                if self.unkn_template is None:
+                    raise IndexError('Feature index out of range')
+                return self.unkn_template % idx
+        raise IndexError('Feature index out of range')
+
+    @property
+    def has_bias(self):
+        return self.bias_name is not None
+
+    def filtered_by_re(self, feature_re):
+        """ Return feature names filtered by a regular expression ``feature_re``,
+        and indices of filtered elements.
+        """
+        indices = []
+        filtered_feature_names = []
+        for idx, name in enumerate(self):
+            if any(re.search(feature_re, n) for n in _feature_names(name)):
+                indices.append(idx)
+                filtered_feature_names.append(name)
+        return (
+            FeatureNames(
+                filtered_feature_names,
+                bias_name=self.bias_name,
+                unkn_template=self.unkn_template,
+            ),
+            indices)
+
+
+def _feature_names(name):
+    if isinstance(name, bytes):
+        return [name.decode('utf8')]
+    elif isinstance(name, list):
+        return [x['name'] for x in name]
+    else:
+        return [name]
+

--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -32,10 +32,7 @@ def _get_top_features(feature_names, coef, top):
     return pos, neg
 
 
-def get_top_features(feature_names, coef, top, feature_re=None):
-    if feature_re is not None:
-        feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
-        coef = coef[flt_indices]
+def get_top_features(feature_names, coef, top):
     pos, neg = _get_top_features(feature_names, coef, top)
     pos_coef = coef > 0
     neg_coef = coef < 0

--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -32,7 +32,10 @@ def _get_top_features(feature_names, coef, top):
     return pos, neg
 
 
-def get_top_features(feature_names, coef, top):
+def get_top_features(feature_names, coef, top, feature_re=None):
+    if feature_re is not None:
+        feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
+        coef = coef[flt_indices]
     pos, neg = _get_top_features(feature_names, coef, top)
     pos_coef = coef > 0
     neg_coef = coef < 0

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -157,11 +157,16 @@ def explain_linear_classifier_weights(clf, vec=None, top=_TOP, target_names=None
     feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
                                                    coef_scale)
     feature_names = get_feature_names(clf, vec, feature_names=feature_names)
+    if feature_re is not None:
+        feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
+
     _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 
     def _features(label_id):
         coef = get_coef(clf, label_id, scale=coef_scale)
-        return get_top_features(feature_names, coef, top, feature_re)
+        if feature_re is not None:
+            coef = coef[flt_indices]
+        return get_top_features(feature_names, coef, top)
 
     def _label(label_id, label):
         return rename_label(label_id, label, target_names)
@@ -335,11 +340,15 @@ def explain_linear_regressor_weights(reg, vec=None, feature_names=None,
     feature_names, coef_scale = handle_hashing_vec(vec, feature_names,
                                                    coef_scale)
     feature_names = get_feature_names(reg, vec, feature_names=feature_names)
+    if feature_re is not None:
+        feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
     _extra_caveats = "\n" + HASHING_CAVEATS if is_invhashing(vec) else ''
 
     def _features(target_id):
         coef = get_coef(reg, target_id, scale=coef_scale)
-        return get_top_features(feature_names, coef, top, feature_re)
+        if feature_re is not None:
+            coef = coef[flt_indices]
+        return get_top_features(feature_names, coef, top)
 
     def _label(target_id, target):
         return rename_label(target_id, target, target_names)

--- a/eli5/sklearn/unhashing.py
+++ b/eli5/sklearn/unhashing.py
@@ -12,7 +12,7 @@ import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_extraction.text import HashingVectorizer, FeatureHasher
 
-from eli5.sklearn.utils import FeatureNames
+from eli5._feature_names import FeatureNames
 
 
 class InvertableHashingVectorizer(BaseEstimator, TransformerMixin):

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -2,6 +2,8 @@
 import numpy as np
 from sklearn.multiclass import OneVsRestClassifier
 
+from eli5._feature_names import FeatureNames
+
 
 def is_multiclass_classifier(clf):
     """
@@ -32,46 +34,6 @@ def is_probabilistic_classifier(clf):
 def has_intercept(estimator):
     """ Return True if an estimator has intercept fit. """
     return getattr(estimator, 'fit_intercept', False)
-
-
-class FeatureNames(object):
-    """
-    A list-like object with feature names. It allows
-    feature names for unknown features to be generated using
-    a provided template.
-    """
-    def __init__(self, feature_names=None, bias_name=None,
-                 unkn_template=None, n_features=None):
-        assert (feature_names is not None or
-                (unkn_template is not None and n_features))
-        self.feature_names = feature_names
-        self.unkn_template = unkn_template
-        self.n_features = n_features or len(feature_names)
-        self.bias_name = bias_name
-
-    def __repr__(self):
-        return '<FeatureNames: {} features {} bias>'.format(
-            self.n_features, 'with' if self.has_bias else 'without')
-
-    def __len__(self):
-        return self.n_features + bool(self.has_bias)
-
-    def __getitem__(self, idx):
-        if isinstance(idx, np.ndarray):
-            return [self[i] for i in idx]
-        n = len(self)
-        if self.has_bias and idx == n - 1:
-            return self.bias_name
-        if 0 <= idx < n:
-            try:
-                return self.feature_names[idx]
-            except (TypeError, KeyError, IndexError):
-                return self.unkn_template % idx
-        raise IndexError('Feature index out of range')
-
-    @property
-    def has_bias(self):
-        return self.bias_name is not None
 
 
 def get_feature_names(clf, vec=None, bias_name='<BIAS>', feature_names=None):

--- a/tests/test_feature_names.py
+++ b/tests/test_feature_names.py
@@ -1,0 +1,17 @@
+from eli5._feature_names import FeatureNames
+
+
+def test_feature_names_filter_by_re():
+    filtered, indices = (
+        FeatureNames(['one', 'two', 'twenty-two']).filtered_by_re('two'))
+    assert indices == [1, 2]
+    assert list(filtered) == ['two', 'twenty-two']
+
+    filtered, indices = (
+        FeatureNames({1: 'two', 3: 'twenty-two', 5: 'two-thirds'}, unkn_template='%d',
+                     n_features=6, bias_name='foo')
+        .filtered_by_re('^two'))
+    assert indices == [1, 5]
+    assert filtered.bias_name == 'foo'
+    assert filtered.unkn_template == '%d'
+    assert list(filtered) == ['two', 'two-thirds', 'foo']

--- a/tests/test_feature_names.py
+++ b/tests/test_feature_names.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eli5._feature_names import FeatureNames
 
 
@@ -15,3 +17,24 @@ def test_feature_names_filter_by_re():
     assert filtered.bias_name == 'foo'
     assert filtered.unkn_template == '%d'
     assert list(filtered) == ['two', 'two-thirds', 'foo']
+
+    filtered, indices = (
+        FeatureNames(unkn_template='x%d', n_features=6).filtered_by_re('x'))
+    assert indices == []
+
+
+def test_init():
+    with pytest.raises(ValueError):
+        FeatureNames()
+    with pytest.raises(ValueError):
+        FeatureNames(unkn_template='%d')
+    with pytest.raises(ValueError):
+        FeatureNames(n_features=10)
+    with pytest.raises(TypeError):
+        FeatureNames({'a', 'b'})
+    FeatureNames(unkn_template='%d', n_features=10)
+    FeatureNames(['a', 'b'])
+    FeatureNames({0: 'a', 1: 'b'})
+
+
+# See also test_sklearn_utils.py::test_get_feature_names

--- a/tests/test_sklearn_crfsuite.py
+++ b/tests/test_sklearn_crfsuite.py
@@ -46,3 +46,14 @@ def test_sklearn_crfsuite(xseq, yseq):
     html_nospaces = html.replace(' ', '').replace("\n", '')
     assert u'солнце:не светит' in html
     assert '<th>sunny</th><th>rainy</th>' in html_nospaces
+
+
+def test_sklearn_crfsuite_feature_re(xseq, yseq):
+    crf = CRF(c1=0.0, c2=0.1, max_iterations=50)
+    crf.fit([xseq], [yseq])
+
+    expl = explain_weights(crf, feature_re=u'(солн|clean)')
+    for expl in format_as_all(expl, crf):
+        assert u'солн' in expl
+        assert u'clean' in expl
+        assert 'walk' not in expl

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -10,6 +10,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.tree import DecisionTreeClassifier
 
+from eli5._feature_names import FeatureNames
 from eli5.sklearn.utils import (
     get_feature_names,
     get_target_names,
@@ -17,7 +18,6 @@ from eli5.sklearn.utils import (
     is_multiclass_classifier,
     is_multitarget_regressor,
     get_num_features,
-    FeatureNames,
 )
 
 


### PR DESCRIPTION
Also move FeatureNames class into it's own module. Fixed #65

I implemented filtering by ``feature_re`` for explain_weights, but got some questions along the way. @kmike what are you thoughts on:
* ``feature_re`` is a string (or a regular expression) that is passed into ``re.search`` - should it be ``re.match`` instead? I always found ``re.match`` less intuitive, but maybe it's just me.
* This feature is not implemented for decision tree - while it's maybe possible to do it somehow, but it's probably not easy, so I'd leave it out for now?
* Do you think it makes sense to add an indication about the number of features filtered out, like we show the number of features not shown? Should it be a separate number (and line)?