### PR TITLE
Add asdict method that returns JSON-encodable object

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-
 from typing import Dict, List, Tuple, Union
 
-from .base_utils import attrs
+import attr
+
+from .base_utils import attrs, numpy_to_python
 
 
 # @attrs decorator used in this file calls @attr.s(slots=True),
@@ -40,7 +41,14 @@ class Explanation(object):
         self.highlight_spaces = highlight_spaces
         self.transition_features = transition_features
 
+    def asdict(self):
+        """ Return a dictionary representing the explanation that can be JSON-encoded.
+        """
+        return numpy_to_python(attr.asdict(self))
+
     def _repr_html_(self):
+        """ HTML formatting for the notebook.
+        """
         from eli5.formatters import fields
         from eli5.formatters.html import format_as_html
         return format_as_html(self, force_weights=False, show=fields.WEIGHTS)

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -31,6 +31,9 @@ def attrs(class_):
     return attr.s(class_, these=these, init=False, slots=True, **attrs_kwargs)
 
 
+_numpy_string_types = (np.string_, np.unicode_) if six.PY2 else np.str_
+
+
 def numpy_to_python(obj):
     """ Convert an nested dict/list/tuple that might contain numpy objects
     to their python equivalents. Return converted object.
@@ -41,7 +44,7 @@ def numpy_to_python(obj):
         return [numpy_to_python(x) for x in obj]
     elif isinstance(obj, FormattedFeatureName):
         return obj.value
-    elif isinstance(obj, np.str_):
+    elif isinstance(obj, _numpy_string_types):
         return six.text_type(obj)
     elif hasattr(obj, 'dtype') and np.isscalar(obj):
         if np.issubdtype(obj, float):

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -1,6 +1,10 @@
 import inspect
+import six
 
 import attr
+import numpy as np
+
+from eli5.formatters.features import FormattedFeatureName
 
 
 def attrs(class_):
@@ -25,3 +29,25 @@ def attrs(class_):
             attrib_kwargs['default'] = init_args.defaults[idx - defaults_shift]
         these[arg] = attr.ib(**attrib_kwargs)
     return attr.s(class_, these=these, init=False, slots=True, **attrs_kwargs)
+
+
+def numpy_to_python(obj):
+    """ Convert an nested dict/list/tuple that might contain numpy objects
+    to their python equivalents. Return converted object.
+    """
+    if isinstance(obj, dict):
+        return {k: numpy_to_python(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, tuple, np.ndarray)):
+        return [numpy_to_python(x) for x in obj]
+    elif isinstance(obj, FormattedFeatureName):
+        return obj.value
+    elif isinstance(obj, np.str_):
+        return six.text_type(obj)
+    elif hasattr(obj, 'dtype') and np.isscalar(obj):
+        if np.issubdtype(obj, float):
+            return float(obj)
+        elif np.issubdtype(obj, int):
+            return int(obj)
+        elif np.issubdtype(obj, bool):
+            return bool(obj)
+    return obj

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,7 +1,8 @@
 import attr
 import pytest
+import numpy as np
 
-from eli5.base_utils import attrs
+from eli5.base_utils import attrs, numpy_to_python
 
 
 def test_attrs_with_default():
@@ -60,3 +61,13 @@ def test_bad_init():
 
     with pytest.raises(AttributeError):
         BadInit(1)
+
+
+def test_numpy_to_python():
+    assert numpy_to_python({
+        'x': np.int32(12),
+        'y': [np.ones(2)],
+    }) == {
+        'x': 12,
+        'y': [[1.0, 1.0]],
+    }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import os
 import inspect
+import json
 from pprint import pprint
 
 from hypothesis.strategies import integers
@@ -19,11 +20,14 @@ def rnd_len_arrays(dtype, min_len=0, max_len=3, elements=None):
 
 
 def format_as_all(res, clf, **kwargs):
-    """ Format explanaton as text and html, print text explanation, and save html.
+    """ Format explanation as text and html, check JSON-encoding,
+    print text explanation, save html, return text and html.
     """
+    expl_dict = res.asdict()
+    pprint(expl_dict)
+    json.dumps(expl_dict)  # check that it can be serialized to JSON
     expl_text = format_as_text(res, **kwargs)
     expl_html = format_as_html(res, **kwargs)
-    pprint(res)
     print(expl_text)
     write_html(clf, expl_html, expl_text)
     return expl_text, expl_html


### PR DESCRIPTION
Explanation object can still contain numpy objects (it may be faster and more convenient), transformation to plain python objects happens in ``numpy_to_python`` object.

Transformation in ``asdict`` loses information anyway (at least it loses types of objects), but here another loss of information occurs for ``FormattedFeatureName`` where we just take it's ``value`` and can not distinguish formatted and not formatted feature names. I think that this might be better to make feature name a wrapper object in any case (we also have unhashed features represented as lists) - but then it's better to do it separately.