### PR TITLE
Public html color functions

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from eli5.base import FeatureWeights
+from eli5.base import FeatureWeights, FeatureWeight
 from .utils import argsort_k_largest, argsort_k_smallest, mask
 
 
@@ -66,16 +66,16 @@ def _get_top_negative_features(feature_names, coef, k):
 
 
 def _positive(features):
-    return [(name, value) for (name, value) in features if value > 0]
+    return [fw for fw in features if fw.weight > 0]
 
 
 def _negative(features):
-    return [(name, value) for (name, value) in features if value < 0]
+    return [fw for fw in features if fw.weight < 0]
 
 
 def _features(indices, feature_names, coef):
     names = mask(feature_names, indices)
     values = mask(coef, indices)
-    return list(zip(names, values))
+    return [FeatureWeight(name, weight) for name, weight in zip(names, values)]
 
 

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -4,13 +4,11 @@ from typing import Dict, List, Tuple, Union
 import attr
 
 from .base_utils import attrs, numpy_to_python
+from .formatters.features import FormattedFeatureName
 
 
 # @attrs decorator used in this file calls @attr.s(slots=True),
 # creating attr.ib entries based on the signature of __init__.
-
-
-FeatureImportance = Tuple[str, float, float]  # name, value, std
 
 
 @attrs
@@ -25,7 +23,7 @@ class Explanation(object):
                  method=None,  # type: str
                  is_regression=False,  # type: bool
                  targets=None,  # type: List[TargetExplanation]
-                 feature_importances=None,  # type: List[FeatureImportance]
+                 feature_importances=None,  # type: List[FeatureWeight]
                  decision_tree=None,  # type: TreeInfo
                  highlight_spaces=None,
                  transition_features=None,  # type: TransitionFeatureWeights
@@ -74,7 +72,8 @@ class TargetExplanation(object):
         self.weighted_spans = weighted_spans
 
 
-Feature = Union[str, Dict]  # Dict is currently used for unhashed features
+# List is currently used for unhashed features
+Feature = Union[str, List, FormattedFeatureName]
 
 
 @attrs
@@ -85,8 +84,8 @@ class FeatureWeights(object):
     :pos_remaining: and :neg_remaining: attributes.
     """
     def __init__(self,
-                 pos,  # type: List[Tuple[Feature, float]]
-                 neg,  # type: List[Tuple[Feature, float]]
+                 pos,  # type: List[FeatureWeight]
+                 neg,  # type: List[FeatureWeight]
                  pos_remaining=0,  # type: int
                  neg_remaining=0,  # type: int
                  ):
@@ -94,6 +93,18 @@ class FeatureWeights(object):
         self.neg = neg
         self.pos_remaining = pos_remaining
         self.neg_remaining = neg_remaining
+
+
+@attrs
+class FeatureWeight(object):
+    def __init__(self,
+                 feature,  # type: Feature
+                 weight,  # type: float
+                 std=None,  # type: float
+                 ):
+        self.feature = feature
+        self.weight = weight
+        self.std = std
 
 
 WeightedSpan = Tuple[

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -23,7 +23,7 @@ template_env.filters.update(dict(
     remaining_weight_color=lambda ws, w_range, pos_neg:
         format_hsl(remaining_weight_color_hsl(ws, w_range, pos_neg)),
     weight_range=lambda w: get_weight_range(w),
-    fi_weight_range=lambda w: max([abs(x[1]) for x in w] or [0]),
+    fi_weight_range=lambda w: max([abs(fw.weight) for fw in w] or [0]),
     format_feature=lambda f, w, hl: _format_feature(f, w, hl_spaces=hl),
     format_decision_tree=lambda tree: _format_decision_tree(tree),
 ))
@@ -171,8 +171,8 @@ def get_weight_range(weights):
     """
     if isinstance(weights, list):
         return max([get_weight_range(t.feature_weights) for t in weights] or [0])
-    return max([abs(coef) for lst in [weights.pos, weights.neg]
-                for _, coef in lst or []] or [0])
+    return max([abs(fw.weight) for lst in [weights.pos, weights.neg]
+                for fw in lst or []] or [0])
 
 
 def remaining_weight_color_hsl(ws, weight_range, pos_neg):
@@ -187,7 +187,7 @@ def remaining_weight_color_hsl(ws, weight_range, pos_neg):
     elif not ws:
         weight = sign * weight_range
     else:
-        weight = min((coef for _, coef in ws), key=abs)
+        weight = min((fw.weight for fw in ws), key=abs)
     return weight_color_hsl(weight, weight_range)
 
 

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -69,12 +69,12 @@ def _error_lines(explanation):
 
 def _feature_importances_lines(explanation, hl_spaces):
     sz = _maxlen(explanation.feature_importances)
-    for name, w, std in explanation.feature_importances:
+    for fw in explanation.feature_importances:
         yield u'{w:0.4f} {plus} {std:0.4f} {feature}'.format(
-            feature=_format_feature(name, hl_spaces).ljust(sz),
-            w=w,
+            feature=_format_feature(fw.feature, hl_spaces).ljust(sz),
+            w=fw.weight,
             plus=_PLUS_MINUS,
-            std=2*std,
+            std=2 * fw.std,
         )
 
 
@@ -133,8 +133,8 @@ def _format_scores(proba, score):
 def _maxlen(feature_weights):
     if not feature_weights:
         return 0
-    return max(len(_format_feature(it[0], hl_spaces=False))
-               for it in feature_weights)
+    return max(len(_format_feature(fw.feature, hl_spaces=False))
+               for fw in feature_weights)
 
 
 def _max_feature_size(explanation):
@@ -146,9 +146,9 @@ def _max_feature_size(explanation):
 def _format_feature_weights(feature_weights, sz, hl_spaces):
     return [
         u'{weight:+8.3f}  {feature}'.format(
-            weight=coef,
-            feature=_format_feature(name, hl_spaces=hl_spaces).ljust(sz))
-        for name, coef in feature_weights]
+            weight=fw.weight,
+            feature=_format_feature(fw.feature, hl_spaces=hl_spaces).ljust(sz))
+        for fw in feature_weights]
 
 
 def _format_remaining(remaining, kind):

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -52,14 +52,14 @@ def should_highlight_spaces(explanation):
     hl_spaces = explanation.highlight_spaces
     if explanation.feature_importances:
         hl_spaces = hl_spaces or any(
-            _has_invisible_spaces(name)
-            for name, _, _ in explanation.feature_importances)
+            _has_invisible_spaces(fw.feature)
+            for fw in explanation.feature_importances)
     if explanation.targets:
         hl_spaces = hl_spaces or any(
-            _has_invisible_spaces(name)
+            _has_invisible_spaces(fw.feature)
             for target in explanation.targets
             for weights in [target.feature_weights.pos, target.feature_weights.neg]
-            for name, _ in weights)
+            for fw in weights)
     return hl_spaces
 
 

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -30,7 +30,7 @@ from sklearn.ensemble import (
 )
 from sklearn.tree import DecisionTreeClassifier
 
-from eli5.base import Explanation, TargetExplanation
+from eli5.base import Explanation, TargetExplanation, FeatureWeight
 from eli5._feature_weights import get_top_features
 from eli5.utils import argsort_k_largest, get_display_names
 from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing
@@ -224,7 +224,7 @@ def explain_rf_feature_importance(clf,
             method="<interpretation method>",
             description="<human readable description>",
             feature_importances=[
-                (feature_name, importance, std_deviation),
+                FeatureWeight(feature_name, importance, std_deviation),
                 ...
             ]
         )
@@ -242,7 +242,7 @@ def explain_rf_feature_importance(clf,
     indices = argsort_k_largest(coef, top)
     names, values, std = feature_names[indices], coef[indices], coef_std[indices]
     return Explanation(
-        feature_importances=list(zip(names, values, std)),
+        feature_importances=[FeatureWeight(*x) for x in zip(names, values, std)],
         description=DESCRIPTION_RANDOM_FOREST,
         estimator=repr(clf),
         method='feature importances',
@@ -268,7 +268,7 @@ def explain_decision_tree(clf,
             description="<human readable description>",
             decision_tree={...tree information},
             feature_importances=[
-                (feature_name, importance, std_deviation),
+                FeatureWeight(feature_name, importance, std_deviation),
                 ...
             ]
         )
@@ -291,7 +291,7 @@ def explain_decision_tree(clf,
         **export_graphviz_kwargs)
 
     return Explanation(
-        feature_importances=list(zip(names, values, std)),
+        feature_importances=[FeatureWeight(*x) for x in zip(names, values, std)],
         decision_tree=tree_info,
         description=DESCRIPTION_DECISION_TREE,
         estimator=repr(clf),

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -30,13 +30,13 @@
             </thead>
             <tbody>
             {% with w_range = expl.feature_importances|fi_weight_range %}
-                {% for name, w, std in expl.feature_importances %}
-                    <tr style="background-color: {{ w|weight_color(w_range) }}; {{ tr_styles }}">
+                {% for fw in expl.feature_importances %}
+                    <tr style="background-color: {{ fw.weight|weight_color(w_range) }}; {{ tr_styles }}">
                         <td style="{{ td1_styles }}">
-                            {{ "%0.4f"|format(w) }} &plusmn; {{ "%0.4f"|format(2 * std) }}
+                            {{ "%0.4f"|format(fw.weight) }} &plusmn; {{ "%0.4f"|format(2 * fw.std) }}
                         </td>
                         <td style="{{ td2_styles }}">
-                            {{ name|format_feature(w, hl_spaces) }}
+                            {{ fw.feature|format_feature(fw.weight, hl_spaces) }}
                         </td>
                     </tr>
                 {% endfor %}

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -21,7 +21,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for name, coef in wts.pos %}
+        {% for fw in wts.pos %}
             {% include "weights_table_row.html" with context %}
         {% endfor %}
         {% if wts.pos_remaining %}
@@ -39,7 +39,7 @@
                 </td>
             </tr>
         {% endif %}
-        {% for name, coef in wts.neg|reverse %}
+        {% for fw in wts.neg|reverse %}
             {% include "weights_table_row.html" with context %}
         {% endfor %}
 

--- a/eli5/templates/weights_table_row.html
+++ b/eli5/templates/weights_table_row.html
@@ -1,8 +1,8 @@
-<tr style="background-color: {{ coef|weight_color(w_range) }}; {{ tr_styles }}">
+<tr style="background-color: {{ fw.weight|weight_color(w_range) }}; {{ tr_styles }}">
     <td style="{{ td1_styles }}">
-        {{ "%+.3f"|format(coef) }}
+        {{ "%+.3f"|format(fw.weight) }}
     </td>
     <td style="{{ td2_styles }}">
-        {{ name|format_feature(coef, hl_spaces) }}
+        {{ fw.feature|format_feature(fw.weight, hl_spaces) }}
     </td>
 </tr>

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -4,7 +4,7 @@ import pytest
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 
-from eli5.base import WeightedSpans
+from eli5.base import WeightedSpans, FeatureWeight
 from eli5 import explain_weights_sklearn, explain_prediction_sklearn
 from eli5.formatters import (
     format_as_text, format_as_html, format_html_styles, FormattedFeatureName)
@@ -175,12 +175,13 @@ def test_override_preserve_density():
 
 
 def test_remaining_weight_color():
+    FW = FeatureWeight
     assert remaining_weight_color_hsl([], 0, 'pos') == weight_color_hsl(1, 1)
     assert remaining_weight_color_hsl([], 2, 'neg') == weight_color_hsl(-2, 2)
-    assert remaining_weight_color_hsl([('a', -1), ('b', -2)], 3, 'neg') == \
-           weight_color_hsl(-1, 3)
-    assert remaining_weight_color_hsl([('a', 1), ('b', 2)], 3, 'pos') == \
-           weight_color_hsl(1, 3)
+    assert (remaining_weight_color_hsl([FW('a', -1), FW('b', -2)], 3, 'neg') ==
+            weight_color_hsl(-1, 3))
+    assert (remaining_weight_color_hsl([FW('a', 1), FW('b', 2)], 3, 'pos') ==
+            weight_color_hsl(1, 3))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -10,7 +10,7 @@ from eli5.formatters import (
     format_as_text, format_as_html, format_html_styles, FormattedFeatureName)
 from eli5.formatters.html import (
     _format_unhashed_feature, render_weighted_spans, _format_single_feature,
-    _format_feature, _remaining_weight_color, _weight_color)
+    _format_feature, remaining_weight_color_hsl, weight_color_hsl)
 from .utils import write_html
 
 
@@ -175,12 +175,12 @@ def test_override_preserve_density():
 
 
 def test_remaining_weight_color():
-    assert _remaining_weight_color([], 0, 'pos') == _weight_color(1, 1)
-    assert _remaining_weight_color([], 2, 'neg') == _weight_color(-2, 2)
-    assert _remaining_weight_color([('a', -1), ('b', -2)], 3, 'neg') == \
-        _weight_color(-1, 3)
-    assert _remaining_weight_color([('a', 1), ('b', 2)], 3, 'pos') == \
-           _weight_color(1, 3)
+    assert remaining_weight_color_hsl([], 0, 'pos') == weight_color_hsl(1, 1)
+    assert remaining_weight_color_hsl([], 2, 'neg') == weight_color_hsl(-2, 2)
+    assert remaining_weight_color_hsl([('a', -1), ('b', -2)], 3, 'neg') == \
+           weight_color_hsl(-1, 3)
+    assert remaining_weight_color_hsl([('a', 1), ('b', 2)], 3, 'pos') == \
+           weight_color_hsl(1, 3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sklearn_text.py
+++ b/tests/test_sklearn_text.py
@@ -1,6 +1,6 @@
 from sklearn.feature_extraction.text import CountVectorizer
 
-from eli5.base import WeightedSpans, FeatureWeights
+from eli5.base import WeightedSpans, FeatureWeights, FeatureWeight as FW
 from eli5.formatters import FormattedFeatureName
 from eli5.sklearn.text import get_weighted_spans
 
@@ -15,8 +15,8 @@ def test_weighted_spans_word():
     w_spans = get_weighted_spans(
         doc, vec,
         FeatureWeights(
-            pos=[('see', 2), ('lemon', 4), ('bias', 8)],
-            neg=[('tree', -6)],
+            pos=[FW('see', 2), FW('lemon', 4), FW('bias', 8)],
+            neg=[FW('tree', -6)],
             neg_remaining=10
         ))
     assert w_spans == WeightedSpans(
@@ -27,7 +27,7 @@ def test_weighted_spans_word():
             ('lemon', [(17, 22)], 4),
             ('tree', [(23, 27)], -6)],
         other=FeatureWeights(
-            pos=[('bias', 8), (hl_in_text, 0)],
+            pos=[FW('bias', 8), FW(hl_in_text, 0)],
             neg=[],
             neg_remaining=10,
         ))
@@ -40,8 +40,8 @@ def test_weighted_spans_word_bigrams():
     w_spans = get_weighted_spans(
         doc, vec,
         FeatureWeights(
-            pos=[('see', 2), ('leaning lemon', 5), ('lemon tree', 8)],
-            neg=[('tree', -6)]))
+            pos=[FW('see', 2), FW('leaning lemon', 5), FW('lemon tree', 8)],
+            neg=[FW('tree', -6)]))
     assert w_spans == WeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
@@ -51,7 +51,7 @@ def test_weighted_spans_word_bigrams():
             ('leaning lemon', [(9, 16), (17, 22)], 5),
             ('lemon tree', [(17, 22), (23, 27)], 8)],
         other=FeatureWeights(
-            pos=[(hl_in_text, 9)],
+            pos=[FW(hl_in_text, 9)],
             neg=[],
         ))
 
@@ -63,8 +63,8 @@ def test_weighted_spans_word_stopwords():
     w_spans = get_weighted_spans(
         doc, vec,
         FeatureWeights(
-            pos=[('see', 2), ('lemon', 5), ('bias', 8)],
-            neg=[('tree', -6)]))
+            pos=[FW('see', 2), FW('lemon', 5), FW('bias', 8)],
+            neg=[FW('tree', -6)]))
     assert w_spans == WeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
@@ -72,8 +72,8 @@ def test_weighted_spans_word_stopwords():
             ('lemon', [(17, 22)], 5),
             ('tree', [(23, 27)], -6)],
         other=FeatureWeights(
-            pos=[('bias', 8), ('see', 2)],
-            neg=[(hl_in_text, -1)],
+            pos=[FW('bias', 8), FW('see', 2)],
+            neg=[FW(hl_in_text, -1)],
         ))
 
 
@@ -84,8 +84,8 @@ def test_weighted_spans_char():
     w_spans = get_weighted_spans(
         doc, vec,
         FeatureWeights(
-            pos=[('see', 2), ('a le', 5), ('on ', 8)],
-            neg=[('lem', -6)]))
+            pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
+            neg=[FW('lem', -6)]))
     assert w_spans == WeightedSpans(
         analyzer='char',
         document='i see: a leaning lemon tree',
@@ -95,7 +95,7 @@ def test_weighted_spans_char():
             ('on ', [(20, 23)], 8),
             ('a le', [(7, 11)], 5)],
         other=FeatureWeights(
-            pos=[(hl_in_text, 9)],
+            pos=[FW(hl_in_text, 9)],
             neg=[],
         ))
 
@@ -119,8 +119,8 @@ def test_weighted_spans_char_wb():
     w_spans = get_weighted_spans(
         doc, vec,
         FeatureWeights(
-            pos=[('see', 2), ('a le', 5), ('on ', 8)],
-            neg=[('lem', -6), (' lem', -4)]))
+            pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
+            neg=[FW('lem', -6), FW(' lem', -4)]))
     assert w_spans == WeightedSpans(
         analyzer='char_wb',
         document='i see: a leaning lemon tree',
@@ -130,7 +130,7 @@ def test_weighted_spans_char_wb():
             ('on ', [(20, 23)], 8),
             (' lem', [(16, 20)], -4)],
         other=FeatureWeights(
-            pos=[('a le', 5), (hl_in_text, 0)],
+            pos=[FW('a le', 5), FW(hl_in_text, 0)],
             neg=[],
         ))
 
@@ -147,11 +147,11 @@ def test_unhashed_features_other():
         doc, vec,
         FeatureWeights(
             pos=[
-                ([{'name': 'foo', 'sign': 1}, {'name': 'see', 'sign': -1}], 2),
-                ([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
+                FW([{'name': 'foo', 'sign': 1}, {'name': 'see', 'sign': -1}], 2),
+                FW([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
             neg=[
-                ([{'name': 'ree', 'sign': 1}, {'name': 'tre', 'sign': 1}], -4),
+                FW([{'name': 'ree', 'sign': 1}, {'name': 'tre', 'sign': 1}], -4),
             ],
         ))
     assert w_spans == WeightedSpans(
@@ -164,7 +164,7 @@ def test_unhashed_features_other():
             ],
         other=FeatureWeights(
             pos=[
-                ([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
+                FW([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
-            neg=[(hl_in_text, -2)],
+            neg=[FW(hl_in_text, -2)],
         ))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,17 +64,19 @@ def write_html(clf, html, text, postfix=''):
 
 
 def get_all_features(feature_weights, with_weights=False):
-    """ Collect a set of all features from feature weights.
+    """ Collect a dict of all features and their weights.
     """
     features = {}
-    for name, value in feature_weights:
-        if isinstance(name, list):
-            features.update((f['name'], value) for f in name)
+    for fw in feature_weights:
+        if isinstance(fw.feature, list):
+            features.update((f['name'], fw.weight) for f in fw.feature)
         else:
-            features[name] = value
+            features[fw.feature] = fw.weight
     return features if with_weights else set(features)
 
 
 def get_names_coefs(feature_weights):
-    return [(format_signed(name[0]) if isinstance(name, list) else name,
-             coef) for name, coef in feature_weights]
+    return [(format_signed(fw.feature[0]) if isinstance(fw.feature, list)
+             else fw.feature,
+             fw.weight)
+            for fw in feature_weights]


### PR DESCRIPTION
Fixes #80 :
- makes ``weight_color_hsl``, ``get_weight_range``, ``format_hsl`` functions from ``eli5.html.formatters`` public (e46e6a1) - now they can be used to add color info for custom rendering.
- use ``FeatureWeight`` class to hold feature weights and feature importances (0d39ab8) - now it's easier to add custom info to feature weight, and it's sometimes more clear what is happening in the code.