### PR TITLE
Don’t limit feature count for explain_prediction by default.

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -22,7 +22,8 @@ def _get_top_features(feature_names, coef, top):
       If ``top`` is a number, ``top`` features with largest absolute
       coefficients are returned. If it is a ``(num_pos, num_neg)`` tuple,
       the function returns no more than ``num_pos`` positive features and
-      no more than ``num_neg`` negative features.
+      no more than ``num_neg`` negative features. ``None`` value means
+      'no limit'.
     """
     if isinstance(top, (list, tuple)):
         num_pos, num_neg = list(top)  # "list" is just for mypy

--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -24,7 +24,7 @@ def explain_weights(estimator, **kwargs):
         Number of features to show. When ``top`` is int, ``top`` features with
         a highest absolute values are shown. When it is (pos, neg) tuple,
         no more than ``pos`` positive features and no more than ``neg``
-        negative features is shown.
+        negative features is shown. ``None`` value means no limit.
 
         This argument may be supported or not, depending on estimator type.
 
@@ -90,7 +90,7 @@ def explain_prediction(estimator, doc, **kwargs):
         Number of features to show. When ``top`` is int, ``top`` features with
         a highest absolute values are shown. When it is (pos, neg) tuple,
         no more than ``pos`` positive features and no more than ``neg``
-        negative features is shown.
+        negative features is shown. ``None`` value means no limit (default).
 
         This argument may be supported or not, depending on estimator type.
 

--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -29,7 +29,7 @@ def explain_weights_lightning(estimator, vec=None, top=20, target_names=None,
 
 @explain_prediction.register(BaseEstimator)
 @singledispatch
-def explain_prediction_lightning(estimator, doc, vec=None, top=20,
+def explain_prediction_lightning(estimator, doc, vec=None, top=None,
                                  target_names=None, target_order=None,
                                  feature_names=None, vectorized=False,
                                  coef_scale=None):

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -40,14 +40,11 @@ from eli5._feature_weights import get_top_features
 from eli5.explain import explain_prediction
 
 
-_TOP = 20
-
-
 @explain_prediction.register(BaseEstimator)
 @singledispatch
 def explain_prediction_sklearn(estimator, doc,
                                vec=None,
-                               top=_TOP,
+                               top=None,
                                target_names=None,
                                target_order=None,
                                feature_names=None,
@@ -83,7 +80,7 @@ def explain_prediction_ovr_sklearn(clf, doc, **kwargs):
 @explain_prediction_sklearn.register(LinearSVC)
 def explain_prediction_linear_classifier(clf, doc,
                                          vec=None,
-                                         top=_TOP,
+                                         top=None,
                                          target_names=None,
                                          target_order=None,
                                          feature_names=None,
@@ -196,7 +193,7 @@ def _handle_vec(clf, doc, vec, vectorized, feature_names):
 @explain_prediction_sklearn.register(SGDRegressor)
 def explain_prediction_linear_regressor(reg, doc,
                                         vec=None,
-                                        top=_TOP,
+                                        top=None,
                                         target_names=None,
                                         target_order=None,
                                         feature_names=None,

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -7,7 +7,7 @@ def argsort_k_largest(x, k):
     """ Return no more than ``k`` indices of largest values. """
     if k == 0:
         return np.array([])
-    if k >= len(x):
+    if k is None or k >= len(x):
         return np.argsort(x)[::-1]
     indices = np.argpartition(x, -k)[-k:]
     values = x[indices]
@@ -18,7 +18,7 @@ def argsort_k_smallest(x, k):
     """ Return no more than ``k`` indices of smallest values. """
     if k == 0:
         return np.array([])
-    if k >= len(x):
+    if k is None or k >= len(x):
         return np.argsort(x)
     indices = np.argpartition(x, k)[:k]
     values = x[indices]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,5 +31,15 @@ def test_argsort_k_smallest_zero(x):
 
 
 @given(rnd_len_arrays(np.float32, 0, 5))
+def test_argsort_k_smallest_None(x):
+    assert len(argsort_k_smallest(x, None)) == len(x)
+
+
+@given(rnd_len_arrays(np.float32, 0, 5))
 def test_argsort_k_largest_zero(x):
     assert len(argsort_k_largest(x, 0)) == 0
+
+
+@given(rnd_len_arrays(np.float32, 0, 5))
+def test_argsort_k_largest_None(x):
+    assert len(argsort_k_largest(x, None)) == len(x)


### PR DESCRIPTION
Fixes #86.