### PR TITLE
Add format_as_dict, remove asdict method

### DIFF
--- a/docs/source/autodocs/formatters.rst
+++ b/docs/source/autodocs/formatters.rst
@@ -14,3 +14,9 @@ eli5.formatters.text
 
 .. automodule:: eli5.formatters.text
     :members:
+
+eli5.formatters.as_dict
+-----------------------
+
+.. automodule:: eli5.formatters.as_dict
+    :members:

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Dict, List, Tuple, Union
 
-import attr
-
-from .base_utils import attrs, numpy_to_python
+from .base_utils import attrs
 from .formatters.features import FormattedFeatureName
 
 
@@ -38,11 +36,6 @@ class Explanation(object):
         self.decision_tree = decision_tree
         self.highlight_spaces = highlight_spaces
         self.transition_features = transition_features
-
-    def asdict(self):
-        """ Return a dictionary representing the explanation that can be JSON-encoded.
-        """
-        return numpy_to_python(attr.asdict(self))
 
     def _repr_html_(self):
         """ HTML formatting for the notebook.

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -1,10 +1,7 @@
 import inspect
-import six
 
 import attr
-import numpy as np
 
-from eli5.formatters.features import FormattedFeatureName
 
 
 def attrs(class_):
@@ -29,28 +26,3 @@ def attrs(class_):
             attrib_kwargs['default'] = init_args.defaults[idx - defaults_shift]
         these[arg] = attr.ib(**attrib_kwargs)
     return attr.s(class_, these=these, init=False, slots=True, **attrs_kwargs)
-
-
-_numpy_string_types = (np.string_, np.unicode_) if six.PY2 else np.str_
-
-
-def numpy_to_python(obj):
-    """ Convert an nested dict/list/tuple that might contain numpy objects
-    to their python equivalents. Return converted object.
-    """
-    if isinstance(obj, dict):
-        return {k: numpy_to_python(v) for k, v in obj.items()}
-    elif isinstance(obj, (list, tuple, np.ndarray)):
-        return [numpy_to_python(x) for x in obj]
-    elif isinstance(obj, FormattedFeatureName):
-        return obj.value
-    elif isinstance(obj, _numpy_string_types):
-        return six.text_type(obj)
-    elif hasattr(obj, 'dtype') and np.isscalar(obj):
-        if np.issubdtype(obj, float):
-            return float(obj)
-        elif np.issubdtype(obj, int):
-            return int(obj)
-        elif np.issubdtype(obj, bool):
-            return bool(obj)
-    return obj

--- a/eli5/formatters/__init__.py
+++ b/eli5/formatters/__init__.py
@@ -9,3 +9,4 @@ from .text import format_as_text
 from .html import format_as_html, format_html_styles
 from . import fields
 from .features import FormattedFeatureName
+from .as_dict import format_as_dict

--- a/eli5/formatters/as_dict.py
+++ b/eli5/formatters/as_dict.py
@@ -10,20 +10,20 @@ def format_as_dict(explanation):
     """ Return a dictionary representing the explanation that can be JSON-encoded.
     It accepts parts of explanation (for example feature weights) as well.
     """
-    return numpy_to_python(attr.asdict(explanation))
+    return _numpy_to_python(attr.asdict(explanation))
 
 
 _numpy_string_types = (np.string_, np.unicode_) if six.PY2 else np.str_
 
 
-def numpy_to_python(obj):
+def _numpy_to_python(obj):
     """ Convert an nested dict/list/tuple that might contain numpy objects
     to their python equivalents. Return converted object.
     """
     if isinstance(obj, dict):
-        return {k: numpy_to_python(v) for k, v in obj.items()}
+        return {k: _numpy_to_python(v) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple, np.ndarray)):
-        return [numpy_to_python(x) for x in obj]
+        return [_numpy_to_python(x) for x in obj]
     elif isinstance(obj, FormattedFeatureName):
         return obj.value
     elif isinstance(obj, _numpy_string_types):

--- a/eli5/formatters/as_dict.py
+++ b/eli5/formatters/as_dict.py
@@ -1,0 +1,38 @@
+import six
+
+import attr
+import numpy as np
+
+from .features import FormattedFeatureName
+
+
+def format_as_dict(explanation):
+    """ Return a dictionary representing the explanation that can be JSON-encoded.
+    It accepts parts of explanation (for example feature weights) as well.
+    """
+    return numpy_to_python(attr.asdict(explanation))
+
+
+_numpy_string_types = (np.string_, np.unicode_) if six.PY2 else np.str_
+
+
+def numpy_to_python(obj):
+    """ Convert an nested dict/list/tuple that might contain numpy objects
+    to their python equivalents. Return converted object.
+    """
+    if isinstance(obj, dict):
+        return {k: numpy_to_python(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, tuple, np.ndarray)):
+        return [numpy_to_python(x) for x in obj]
+    elif isinstance(obj, FormattedFeatureName):
+        return obj.value
+    elif isinstance(obj, _numpy_string_types):
+        return six.text_type(obj)
+    elif hasattr(obj, 'dtype') and np.isscalar(obj):
+        if np.issubdtype(obj, float):
+            return float(obj)
+        elif np.issubdtype(obj, int):
+            return int(obj)
+        elif np.issubdtype(obj, bool):
+            return bool(obj)
+    return obj

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,8 +1,7 @@
 import attr
 import pytest
-import numpy as np
 
-from eli5.base_utils import attrs, numpy_to_python
+from eli5.base_utils import attrs
 
 
 def test_attrs_with_default():
@@ -61,13 +60,3 @@ def test_bad_init():
 
     with pytest.raises(AttributeError):
         BadInit(1)
-
-
-def test_numpy_to_python():
-    assert numpy_to_python({
-        'x': np.int32(12),
-        'y': [np.ones(2)],
-    }) == {
-        'x': 12,
-        'y': [[1.0, 1.0]],
-    }

--- a/tests/test_formatters_as_dict.py
+++ b/tests/test_formatters_as_dict.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from eli5.base import Explanation, TargetExplanation, FeatureWeights, FeatureWeight
+from eli5.formatters.as_dict import numpy_to_python, format_as_dict
+
+
+# format_as_dict is called in eli5.tests.utils.format_as_all
+
+
+def test_numpy_to_python():
+    assert numpy_to_python({
+        'x': np.int32(12),
+        'y': [np.ones(2)],
+    }) == {
+        'x': 12,
+        'y': [[1.0, 1.0]],
+    }
+
+
+def test_format_as_dict():
+    assert format_as_dict(Explanation(
+        estimator='some estimator',
+        targets=[
+            TargetExplanation(
+                'y', feature_weights=FeatureWeights(
+                    pos=[FeatureWeight('a', np.float32(13.0))],
+                    neg=[])),
+        ],
+    )) == {'estimator': 'some estimator',
+           'targets': [
+               {'target': 'y',
+                'feature_weights': {
+                    'pos': [{'feature': 'a', 'weight': 13.0, 'std': None}],
+                    'pos_remaining': 0,
+                    'neg': [],
+                    'neg_remaining': 0,
+                },
+                'score': None,
+                'proba': None,
+                'weighted_spans': None,
+                },
+           ],
+           'decision_tree': None,
+           'description': None,
+           'error': None,
+           'feature_importances': None,
+           'highlight_spaces': None,
+           'is_regression': False,
+           'method': None,
+           'transition_features': None
+           }

--- a/tests/test_formatters_as_dict.py
+++ b/tests/test_formatters_as_dict.py
@@ -1,14 +1,15 @@
 import numpy as np
 
-from eli5.base import Explanation, TargetExplanation, FeatureWeights, FeatureWeight
-from eli5.formatters.as_dict import numpy_to_python, format_as_dict
+from eli5.base import (
+    Explanation, TargetExplanation, FeatureWeights, FeatureWeight)
+from eli5.formatters.as_dict import format_as_dict, _numpy_to_python
 
 
 # format_as_dict is called in eli5.tests.utils.format_as_all
 
 
 def test_numpy_to_python():
-    assert numpy_to_python({
+    assert _numpy_to_python({
         'x': np.int32(12),
         'y': [np.ones(2)],
     }) == {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from pprint import pprint
 from hypothesis.strategies import integers
 from hypothesis.extra.numpy import arrays
 
-from eli5.formatters import format_as_text, format_as_html
+from eli5.formatters import format_as_text, format_as_html, format_as_dict
 from eli5.formatters.html import html_escape
 from eli5.formatters.text import format_signed
 
@@ -23,7 +23,7 @@ def format_as_all(res, clf, **kwargs):
     """ Format explanation as text and html, check JSON-encoding,
     print text explanation, save html, return text and html.
     """
-    expl_dict = res.asdict()
+    expl_dict = format_as_dict(res)
     pprint(expl_dict)
     json.dumps(expl_dict)  # check that it can be serialized to JSON
     expl_text = format_as_text(res, **kwargs)


### PR DESCRIPTION
Apart from consistency with other formatters, another benefit is that it's possible to use format_as_dict on parts of explanation too, which can be useful when sending data to other clients.