### PR TITLE
Apply feature_re to bias too

### DIFF
--- a/eli5/_feature_names.py
+++ b/eli5/_feature_names.py
@@ -36,10 +36,9 @@ class FeatureNames(object):
     def __getitem__(self, idx):
         if isinstance(idx, np.ndarray):
             return [self[i] for i in idx]
-        n = len(self)
-        if self.has_bias and idx == n - 1:
+        if self.has_bias and idx == self.bias_idx:
             return self.bias_name
-        if 0 <= idx < n:
+        if 0 <= idx < self.n_features:
             try:
                 return self.feature_names[idx]
             except (TypeError, KeyError, IndexError):
@@ -49,6 +48,11 @@ class FeatureNames(object):
     @property
     def has_bias(self):
         return self.bias_name is not None
+
+    @property
+    def bias_idx(self):
+        if self.has_bias:
+            return self.n_features
 
     def filtered_by_re(self, feature_re):
         """ Return feature names filtered by a regular expression ``feature_re``,
@@ -72,6 +76,8 @@ class FeatureNames(object):
             if any(filter_fn(n) for n in _feature_names(name)):
                 indices.append(idx)
                 filtered_feature_names.append(name)
+        if self.has_bias and filter_fn(self.bias_name):
+            indices.append(self.bias_idx)
         return (
             FeatureNames(
                 filtered_feature_names,

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -194,11 +194,23 @@ def test_explain_linear_feature_re(newsgroups_train, vec):
     if isinstance(vec, HashingVectorizer):
         vec = InvertableHashingVectorizer(vec)
         vec.fit(docs)
+
     res = explain_weights(clf, vec=vec, feature_re='^ath')
-    for expl in format_as_all(res, clf):
+    text_expl, _ = expls = format_as_all(res, clf)
+    for expl in expls:
         assert 'atheists' in expl
         assert 'atheism' in expl
         assert 'space' not in expl
+        assert 'BIAS' not in expl
+
+    res = explain_weights(clf, vec=vec, feature_re='(^ath|^<BIAS>$)')
+    text_expl, _ = expls = format_as_all(res, clf)
+    for expl in expls:
+        assert 'atheists' in expl
+        assert 'atheism' in expl
+        assert 'space' not in expl
+        assert 'BIAS' in expl
+    assert '<BIAS>' in text_expl
 
 
 @pytest.mark.parametrize(['clf'], [


### PR DESCRIPTION
Fixes #92 - now it's possible to include bias with ``feature_re`` with a regexp like ``(old_regexp|^<BIAS>$)``