### PR TITLE
Highlight features in text for FeatureUnion

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -56,7 +56,7 @@ class TargetExplanation(object):
                  feature_weights,  # type: FeatureWeights
                  proba=None,  # type: float
                  score=None,  # type: float
-                 weighted_spans=None,  # type: WeightedSpans
+                 weighted_spans=None,  # type: List[WeightedSpans]
                  ):
         self.target = target
         self.feature_weights = feature_weights
@@ -120,11 +120,13 @@ class WeightedSpans(object):
                  document,  # type: str
                  weighted_spans,  # type: List[WeightedSpan]
                  other=None,  # type: FeatureWeights
+                 vec_name=None,  # type: str
                  ):
         self.analyzer = analyzer
         self.document = document
         self.weighted_spans = weighted_spans
         self.other = other
+        self.vec_name = vec_name
 
 
 @attrs

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -100,16 +100,11 @@ class FeatureWeight(object):
         self.std = std
 
 
-WeightedSpan = Tuple[
-    Feature,
-    List[Tuple[int, int]],  # list of spans (start, end) for this feature
-    float,  # feature weight
-]
-
-
 @attrs
 class WeightedSpans(object):
-    # TODO - docstring
+    """ Holds highlighted spans for parts of document - a DocWeightedSpans object
+    for each vectorizer, and other features not highlighted anywhere.
+    """
     def __init__(self,
                  docs_weighted_spans,  # type: List[DocWeightedSpans]
                  other=None,  # type: FeatureWeights
@@ -118,24 +113,31 @@ class WeightedSpans(object):
         self.other = other
 
 
+WeightedSpan = Tuple[
+    Feature,
+    List[Tuple[int, int]],  # list of spans (start, end) for this feature
+    float,  # feature weight
+]
+
+
 @attrs
 class DocWeightedSpans(object):
-    """ Features highlighted in text. :analyzer: is a type of the analyzer
-    (for example "char" or "word"), and :document: is a pre-processed document
-    before applying the analyzed. :weighted_spans: holds a list of spans
-    (see above) for features found in text (span indices correspond to
-    :document:), and :other: holds weights for features not highlighted in text.
+    """ Features highlighted in text. :document: is a pre-processed document
+    before applying the analyzer. :weighted_spans: holds a list of spans
+    for features found in text (span indices correspond to
+    :document:). :preserve_density: determines how features are colored
+    when doing formatting - it is better set to True for char features
+    and to False for word features.
     """
-    # FIXME - fix docstring
     def __init__(self,
-                 analyzer,  # type: str
                  document,  # type: str
                  spans,  # type: List[WeightedSpan]
+                 preserve_density=None,  # type: bool
                  vec_name=None,  # type: str
                  ):
-        self.analyzer = analyzer
         self.document = document
         self.spans = spans
+        self.preserve_density = preserve_density
         self.vec_name = vec_name
 
 

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -112,7 +112,7 @@ class WeightedSpans(object):
     # TODO - docstring
     def __init__(self,
                  docs_weighted_spans,  # type: List[DocWeightedSpans]
-                 other,  # type: FeatureWeights
+                 other=None,  # type: FeatureWeights
                  ):
         self.docs_weighted_spans = docs_weighted_spans
         self.other = other

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -56,7 +56,7 @@ class TargetExplanation(object):
                  feature_weights,  # type: FeatureWeights
                  proba=None,  # type: float
                  score=None,  # type: float
-                 weighted_spans=None,  # type: List[WeightedSpans]
+                 weighted_spans=None,  # type: WeightedSpans
                  ):
         self.target = target
         self.feature_weights = feature_weights
@@ -109,23 +109,33 @@ WeightedSpan = Tuple[
 
 @attrs
 class WeightedSpans(object):
+    # TODO - docstring
+    def __init__(self,
+                 docs_weighted_spans,  # type: List[DocWeightedSpans]
+                 other,  # type: FeatureWeights
+                 ):
+        self.docs_weighted_spans = docs_weighted_spans
+        self.other = other
+
+
+@attrs
+class DocWeightedSpans(object):
     """ Features highlighted in text. :analyzer: is a type of the analyzer
     (for example "char" or "word"), and :document: is a pre-processed document
     before applying the analyzed. :weighted_spans: holds a list of spans
     (see above) for features found in text (span indices correspond to
     :document:), and :other: holds weights for features not highlighted in text.
     """
+    # FIXME - fix docstring
     def __init__(self,
                  analyzer,  # type: str
                  document,  # type: str
-                 weighted_spans,  # type: List[WeightedSpan]
-                 other=None,  # type: FeatureWeights
+                 spans,  # type: List[WeightedSpan]
                  vec_name=None,  # type: str
                  ):
         self.analyzer = analyzer
         self.document = document
-        self.weighted_spans = weighted_spans
-        self.other = other
+        self.spans = spans
         self.vec_name = vec_name
 
 

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -3,7 +3,6 @@ import inspect
 import attr
 
 
-
 def attrs(class_):
     """ Like attr.s with slots=True,
     but with attributes extracted from __init__ method signature.
@@ -13,10 +12,14 @@ def attrs(class_):
     do not want to repeat attribute definitions in the class body.
     """
     attrs_kwargs = {}
-    for method in ['repr', 'cmp', 'hash']:
-        if '__{}__'.format(method) in class_.__dict__:
+    for method, kw_name in [
+            ('__repr__', 'repr'),
+            ('__eq__', 'cmp'),
+            ('__hash__', 'hash'),
+            ]:
+        if method in class_.__dict__:
             # Allow to redefine a special method (or else attr.s will do it)
-            attrs_kwargs[method] = False
+            attrs_kwargs[kw_name] = False
     init_args = inspect.getargspec(class_.__init__)
     defaults_shift = len(init_args.args) - len(init_args.defaults or []) - 1
     these = {}

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -8,8 +8,9 @@ from jinja2 import Environment, PackageLoader
 
 from eli5 import _graphviz
 from eli5.base import TargetExplanation
+from eli5.utils import max_or_0
 from .utils import (
-    format_signed, replace_spaces, should_highlight_spaces, max_or_0)
+    format_signed, replace_spaces, should_highlight_spaces)
 from . import fields
 from .features import FormattedFeatureName
 from .trees import tree2text

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -13,9 +13,7 @@ from .utils import (
 from . import fields
 from .features import FormattedFeatureName
 from .trees import tree2text
-from .text_helpers import (
-    prepare_weighted_spans, merge_weighted_spans_others,
-    PreparedWeightedSpans)
+from .text_helpers import prepare_weighted_spans, PreparedWeightedSpans
 
 
 template_env = Environment(
@@ -57,7 +55,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
 
     rendered_weighted_spans = render_targets_weighted_spans(
         targets, preserve_density)
-    weighted_spans_others = [merge_weighted_spans_others(t) for t in targets]
+    weighted_spans_others = [
+        t.weighted_spans.other if t.weighted_spans else None for t in targets]
 
     return template.render(
         include_styles=include_styles,

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -14,7 +14,7 @@ from . import fields
 from .features import FormattedFeatureName
 from .trees import tree2text
 from .text_helpers import (
-    get_prepared_weighted_spans, merge_weighted_spans_others,
+    prepare_weighted_spans, merge_weighted_spans_others,
     PreparedWeightedSpans)
 
 
@@ -103,7 +103,7 @@ def render_targets_weighted_spans(targets, preserve_density):
     Function must accept a list in order to select consistent weight
     ranges across all targets.
     """
-    prepared_weighted_spans = get_prepared_weighted_spans(
+    prepared_weighted_spans = prepare_weighted_spans(
         targets, preserve_density)
     return [
         '<br/>'.join(

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -107,8 +107,8 @@ def render_targets_weighted_spans(targets, preserve_density):
     return [
         '<br/>'.join(
             '{}{}'.format(
-                '<b>{}:</b> '.format(pws.weighted_spans.vec_name)
-                if pws.weighted_spans.vec_name else '',
+                '<b>{}:</b> '.format(pws.doc_weighted_spans.vec_name)
+                if pws.doc_weighted_spans.vec_name else '',
                 render_weighted_spans(pws))
             for pws in pws_lst)
         if pws_lst else None
@@ -122,7 +122,7 @@ def render_weighted_spans(pws):
     return ''.join(
         _colorize(token, weight, pws.weight_range)
         for token, weight in zip(
-            pws.weighted_spans.document, pws.char_weights))
+            pws.doc_weighted_spans.document, pws.char_weights))
 
 
 def _colorize(token, weight, weight_range):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -142,7 +142,7 @@ def _renamed(fw, ws):
         fw.feature = FormattedFeatureName(renamed(fw.feature.value))
     elif isinstance(fw.feature, list):
         fw.feature = [
-            {'name': renamed(x['name']), 'sing': x['sign']} for x in fw.feature]
+            {'name': renamed(x['name']), 'sign': x['sign']} for x in fw.feature]
     else:
         fw.feature = renamed(fw.feature)
     return fw

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -14,12 +14,11 @@ def get_char_weights(doc_weighted_spans, preserve_density=None):
     If preserve_density is True, then color for longer fragments will be
     less intensive than for shorter fragments, so that "sum" of intensities
     will correspond to feature weight.
-    If preserve_density is None, then it's value is chosen depending on
-    analyzer kind: it is preserved for "char" and "char_wb" analyzers,
-    and not preserved for "word" analyzers.
+    If preserve_density is None, then it's value is taken from
+    the corresponding attribute of doc_weighted_spans.
     """
     if preserve_density is None:
-        preserve_density = doc_weighted_spans.analyzer.startswith('char')
+        preserve_density = doc_weighted_spans.preserve_density
     char_weights = np.zeros(len(doc_weighted_spans.document))
     feature_counts = Counter(f for f, _, _ in doc_weighted_spans.spans)
     for feature, spans, weight in doc_weighted_spans.spans:

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -34,11 +34,11 @@ def get_char_weights(doc_weighted_spans, preserve_density=None):
 @attrs
 class PreparedWeightedSpans(object):
     def __init__(self,
-                 weighted_spans,  # type: WeightedSpans
+                 doc_weighted_spans,  # type: DocWeightedSpans
                  char_weights,  # type: np.ndarray
                  weight_range,  # type: float
                  ):
-        self.weighted_spans = weighted_spans
+        self.doc_weighted_spans = doc_weighted_spans
         self.char_weights = char_weights
         self.weight_range = weight_range
 
@@ -46,8 +46,8 @@ class PreparedWeightedSpans(object):
         # Working around __eq__ on numpy arrays
         if self.__class__ == other.__class__:
             return (
-                (self.weighted_spans, self.weight_range) ==
-                (other.weighted_spans, other.weight_range) and
+                (self.doc_weighted_spans, self.weight_range) ==
+                (other.doc_weighted_spans, other.weight_range) and
                 self.char_weights.shape == other.char_weights.shape and
                 np.allclose(self.char_weights, other.char_weights))
         return False

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -44,6 +44,15 @@ class PreparedWeightedSpans(object):
         self.char_weights = char_weights
         self.weight_range = weight_range
 
+    def __eq__(self, other):
+        # Working around __eq__ on numpy arrays
+        if self.__class__ == other.__class__:
+            return (
+                (self.weighted_spans, self.weight_range) ==
+                (other.weighted_spans, other.weight_range) and
+                self.char_weights.shape == other.char_weights.shape and
+                np.allclose(self.char_weights, other.char_weights))
+        return False
 
 def get_prepared_weighted_spans(targets, preserve_density):
     # type: (List[TargetExplanation], bool) -> List[List[PreparedWeightedSpans]]

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -54,7 +54,8 @@ class PreparedWeightedSpans(object):
                 np.allclose(self.char_weights, other.char_weights))
         return False
 
-def get_prepared_weighted_spans(targets, preserve_density):
+
+def prepare_weighted_spans(targets, preserve_density=None):
     # type: (List[TargetExplanation], bool) -> List[List[PreparedWeightedSpans]]
     """ Return weighted spans prepared for rendering.
     Calculate a separate weight range for each different weighted
@@ -79,8 +80,7 @@ def get_prepared_weighted_spans(targets, preserve_density):
         for t, t_char_weights in zip(targets, targets_char_weights)]
 
 
-def merge_weighted_spans_others(
-        target, with_vec_name='{}: {}'.format):
+def merge_weighted_spans_others(target, with_vec_name='{}: {}'.format):
     # type: (TargetExplanation, Callable[[str, str], str]) -> Optional[FeatureWeights]
     """ Merge "others" of a list of weighted spans into a single "others" field.
     with_vec_name is a function that takes vectorizer name and feature name

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from eli5.base import TargetExplanation, WeightedSpans, DocWeightedSpans
 from eli5.base_utils import attrs
-from .utils import max_or_0
+from eli5.utils import max_or_0
 
 
 def get_char_weights(doc_weighted_spans, preserve_density=None):

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -1,0 +1,108 @@
+from collections import Counter
+import copy
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+
+from eli5.base import (
+    FeatureWeights, FormattedFeatureName, TargetExplanation, WeightedSpans)
+from eli5.base_utils import attrs
+from .utils import max_or_0
+
+
+def get_char_weights(weighted_spans, preserve_density=None):
+    # type: (WeightedSpans, bool) -> np.ndarray
+    """ Return character weights for a text document with highlighted features.
+    If preserve_density is True, then color for longer fragments will be
+    less intensive than for shorter fragments, so that "sum" of intensities
+    will correspond to feature weight.
+    If preserve_density is None, then it's value is chosen depending on
+    analyzer kind: it is preserved for "char" and "char_wb" analyzers,
+    and not preserved for "word" analyzers.
+    """
+    if preserve_density is None:
+        preserve_density = weighted_spans.analyzer.startswith('char')
+    char_weights = np.zeros(len(weighted_spans.document))
+    feature_counts = Counter(f for f, _, _ in weighted_spans.weighted_spans)
+    for feature, spans, weight in weighted_spans.weighted_spans:
+        for start, end in spans:
+            if preserve_density:
+                weight /= (end - start)
+            weight /= feature_counts[feature]
+            char_weights[start:end] += weight
+    return char_weights
+
+
+@attrs
+class PreparedWeightedSpans(object):
+    def __init__(self,
+                 weighted_spans,  # type: WeightedSpans
+                 char_weights,  # type: np.ndarray
+                 weight_range,  # type: float
+                 ):
+        self.weighted_spans = weighted_spans
+        self.char_weights = char_weights
+        self.weight_range = weight_range
+
+
+def get_prepared_weighted_spans(targets, preserve_density):
+    # type: (List[TargetExplanation], bool) -> List[List[PreparedWeightedSpans]]
+    """ Return weighted spans prepared for rendering.
+    Calculate a separate weight range for each different weighted
+    span (for each different index): each target has the same number
+    of weighted spans.
+    """
+    targets_char_weights = [
+        [get_char_weights(ws, preserve_density=preserve_density)
+         for ws in t.weighted_spans] if t.weighted_spans else None
+        for t in targets]  # type: List[List[np.ndarray]]
+    max_idx = max_or_0(len(ch_w or []) for ch_w in targets_char_weights)
+    spans_weight_ranges = [
+        max_or_0(
+            abs(x) for char_weights in targets_char_weights
+            for x in char_weights[idx] if char_weights is not None)
+        for idx in range(max_idx)]
+    return [
+        [PreparedWeightedSpans(ws, char_weights, weight_range)
+         for ws, char_weights, weight_range in zip(
+            t.weighted_spans, t_char_weights, spans_weight_ranges)]
+        if t_char_weights is not None else None
+        for t, t_char_weights in zip(targets, targets_char_weights)]
+
+
+def merge_weighted_spans_others(
+        target, with_vec_name='{}: {}'.format):
+    # type: (TargetExplanation, Callable[[str, str], str]) -> Optional[FeatureWeights]
+    """ Merge "others" of a list of weighted spans into a single "others" field.
+    with_vec_name is a function that takes vectorizer name and feature name
+    to produce the new feature name.
+    """
+    weighted_spans = target.weighted_spans
+    if not weighted_spans:
+        return None
+    if len(weighted_spans) == 1:
+        return weighted_spans[0].other
+    return FeatureWeights(
+        pos=[_renamed(fw, ws, with_vec_name) for ws in weighted_spans
+             for fw in ws.other.pos],
+        neg=[_renamed(fw, ws, with_vec_name) for ws in weighted_spans
+             for fw in ws.other.neg],
+        # All should be the same, so min is fine
+        pos_remaining=min(ws.other.pos_remaining for ws in weighted_spans),
+        neg_remaining=min(ws.other.neg_remaining for ws in weighted_spans),
+    )
+
+
+def _renamed(fw, ws, with_vec_name):
+    if not ws.vec_name:
+        return fw
+    fw = copy.copy(fw)
+    renamed = lambda x: with_vec_name(ws.vec_name, x)
+    if isinstance(fw.feature, FormattedFeatureName):
+        fw.feature = FormattedFeatureName(renamed(fw.feature.value))
+    elif isinstance(fw.feature, list):
+        fw.feature = [
+            {'name': renamed(x['name']), 'sign': x['sign']} for x in fw.feature]
+    else:
+        fw.feature = renamed(fw.feature)
+    return fw

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -68,3 +68,8 @@ def _has_invisible_spaces(name):
     if isinstance(name, list):
         return any(_has_invisible_spaces(n['name']) for n in name)
     return name.startswith(' ') or name.endswith(' ')
+
+
+def max_or_0(it):
+    lst = list(it)
+    return max(lst) if lst else 0

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Union
+from typing import Union, List, Dict
 
 from eli5.base import Explanation
 
@@ -68,8 +68,3 @@ def _has_invisible_spaces(name):
     if isinstance(name, list):
         return any(_has_invisible_spaces(n['name']) for n in name)
     return name.startswith(' ') or name.endswith(' ')
-
-
-def max_or_0(it):
-    lst = list(it)
-    return max(lst) if lst else 0

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -139,7 +139,7 @@ def explain_prediction_linear_classifier(clf, doc,
 
 
 def _add_weighted_spans(doc, vec, target_expl):
-    if isinstance(doc, six.string_types) and vec is not None:
+    if vec is not None:
         weighted_spans = get_weighted_spans(
             doc, vec, target_expl.feature_weights)
         if weighted_spans:

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -3,7 +3,6 @@ from singledispatch import singledispatch
 
 import numpy as np
 import scipy.sparse as sp
-import six
 from sklearn.base import BaseEstimator
 from sklearn.feature_extraction.text import HashingVectorizer
 from sklearn.linear_model import (
@@ -123,7 +122,7 @@ def explain_prediction_linear_classifier(clf, doc,
                 score=score[label_id],
                 proba=proba[label_id] if proba is not None else None,
             )
-            _add_weighted_spans(doc, vec, target_expl)
+            _add_weighted_spans(doc, vec, vectorized, target_expl)
             res.targets.append(target_expl)
     else:
         target_expl = TargetExplanation(
@@ -132,14 +131,14 @@ def explain_prediction_linear_classifier(clf, doc,
             score=score,
             proba=proba[1] if proba is not None else None,
         )
-        _add_weighted_spans(doc, vec, target_expl)
+        _add_weighted_spans(doc, vec, vectorized, target_expl)
         res.targets.append(target_expl)
 
     return res
 
 
-def _add_weighted_spans(doc, vec, target_expl):
-    if vec is not None:
+def _add_weighted_spans(doc, vec, vectorized, target_expl):
+    if vec is not None and not vectorized:
         weighted_spans = get_weighted_spans(
             doc, vec, target_expl.feature_weights)
         if weighted_spans:
@@ -230,7 +229,7 @@ def explain_prediction_linear_regressor(reg, doc,
                 feature_weights=_weights(label_id),
                 score=score[label_id],
             )
-            _add_weighted_spans(doc, vec, target_expl)
+            _add_weighted_spans(doc, vec, vectorized, target_expl)
             res.targets.append(target_expl)
     else:
         target_expl = TargetExplanation(
@@ -238,7 +237,7 @@ def explain_prediction_linear_regressor(reg, doc,
             feature_weights=_weights(0),
             score=score,
         )
-        _add_weighted_spans(doc, vec, target_expl)
+        _add_weighted_spans(doc, vec, vectorized, target_expl)
         res.targets.append(target_expl)
 
     return res

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -82,37 +82,6 @@ def get_weighted_spans_from_union(doc, vec_union, all_feature_weights):
 
     return weighted_spans or None
 
-"""
-        shifted_weighted_spans = []
-        document_parts = []
-        for vec_name, ws in named_weighted_spans:
-            document_parts.append('{}{}: '.format(
-                '\n' if document_parts else '',  # FIXME?
-                vec_name,
-            ))
-            shift = sum(map(len, document_parts))
-            shifted_weighted_spans.extend(
-                (f, [(s + shift, e + shift) for s, e in spans], w)
-                for f, spans, w in ws.weighted_spans)
-            document_parts.append(ws.document)
-        document = ''.join(document_parts)  # don't change "''" (spans!)
-
-        return WeightedSpans(
-            analyzer=', '.join(sorted(
-                {ws.analyzer for _, ws in named_weighted_spans})),
-            document=document,
-            weighted_spans=shifted_weighted_spans,
-            other=FeatureWeights(
-                pos=[fw for _, ws in named_weighted_spans
-                     for fw in ws.other.pos],
-                neg=[fw for _, ws in named_weighted_spans
-                     for fw in ws.other.neg],
-                pos_remaining=all_feature_weights.pos_remaining,
-                neg_remaining=all_feature_weights.neg_remaining,
-            ),
-        )
-"""
-
 
 def _get_other(feature_weights, feature_weights_dict, found_features):
     # search for items that were not accounted at all.

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 from six.moves import xrange
 from sklearn.feature_extraction.text import VectorizerMixin
@@ -20,7 +20,7 @@ def get_weighted_spans(doc, vec, feature_weights):
     if isinstance(vec, InvertableHashingVectorizer):
         vec = vec.vec
     if not isinstance(vec, VectorizerMixin):
-        return
+        return None
 
     def _get_features(feature):
         if isinstance(feature, list):
@@ -36,7 +36,7 @@ def get_weighted_spans(doc, vec, feature_weights):
 
     span_analyzer, preprocessed_doc = _build_span_analyzer(doc, vec)
     if span_analyzer is None:
-        return
+        return None
 
     weighted_spans = []
     found_features = {}

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -1,101 +1,127 @@
 import re
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from six.moves import xrange
 from sklearn.feature_extraction.text import VectorizerMixin
 from sklearn.pipeline import FeatureUnion
 
-from eli5.base import WeightedSpans, FeatureWeights, FeatureWeight
+from eli5.base import (
+    DocWeightedSpans, WeightedSpans, FeatureWeights, FeatureWeight)
 from eli5.sklearn.unhashing import InvertableHashingVectorizer
 from eli5.formatters import FormattedFeatureName
 
 
 def get_weighted_spans(doc, vec, feature_weights):
-    # type: (Any, Any, FeatureWeights) -> Optional[List[WeightedSpans]]
+    # type: (Any, Any, FeatureWeights) -> Optional[WeightedSpans]
     """ If possible, return a dict with preprocessed document and a list
     of spans with weights, corresponding to features in the document.
     """
     if isinstance(vec, FeatureUnion):
-        return get_weighted_spans_from_union(doc, vec, feature_weights)
+        return _get_weighted_spans_from_union(doc, vec, feature_weights)
+    else:
+        result = _get_doc_weighted_spans(doc, vec, feature_weights)
+        if result is not None:
+            found_features, doc_weighted_spans = result
+            return WeightedSpans(
+                [doc_weighted_spans],
+                other=_get_other(feature_weights, [('', found_features)]),
+            )
+
+
+FoundFeatures = Dict[Tuple[str, int], float]
+
+
+def _get_doc_weighted_spans(doc, vec, feature_weights, feature_fn=None):
+    # type: (Any, Any, FeatureWeights, Callable[[str], str]) -> Optional[Tuple[FoundFeatures, DocWeightedSpans]]
     if isinstance(vec, InvertableHashingVectorizer):
         vec = vec.vec
     if not isinstance(vec, VectorizerMixin):
         return None
 
-    def _get_features(feature):
-        if isinstance(feature, list):
-            return [f['name'] for f in feature]
-        else:
-            return [feature]
+    span_analyzer, preprocessed_doc = _build_span_analyzer(doc, vec)
+    if span_analyzer is None:
+        return None
 
     # (group, idx) is a feature key here
     feature_weights_dict = {
         f: (fw.weight, (group, idx)) for group in ['pos', 'neg']
         for idx, fw in enumerate(getattr(feature_weights, group))
-        for f in _get_features(fw.feature)}
+        for f in _get_features(fw.feature, feature_fn)}
 
-    span_analyzer, preprocessed_doc = _build_span_analyzer(doc, vec)
-    if span_analyzer is None:
-        return None
-
-    weighted_spans = []
+    spans = []
     found_features = {}
-    for spans, feature in span_analyzer(preprocessed_doc):
+    for f_spans, feature in span_analyzer(preprocessed_doc):
         try:
             weight, key = feature_weights_dict[feature]
         except KeyError:
             pass
         else:
-            weighted_spans.append((feature, spans, weight))
+            spans.append((feature, f_spans, weight))
             found_features[key] = weight
 
-    return [WeightedSpans(
+    return found_features, DocWeightedSpans(
         analyzer=vec.analyzer,
         document=preprocessed_doc,
-        weighted_spans=weighted_spans,
-        other=_get_other(
-            feature_weights, feature_weights_dict, found_features),
-    )]
+        spans=spans,
+    )
 
 
-def get_weighted_spans_from_union(doc, vec_union, all_feature_weights):
-    weighted_spans = []  # type: List[WeightedSpans]
+def _get_features(feature, feature_fn=None):
+    if isinstance(feature, list):
+        features = [f['name'] for f in feature]
+    else:
+        features = [feature]
+    if feature_fn:
+        features = list(filter(None, map(feature_fn, features)))
+    return features
+
+
+def _get_weighted_spans_from_union(doc, vec_union, feature_weights):
+    # type: (Any, FeatureUnion, FeatureWeights) -> Optional[WeightedSpans]
+    docs_weighted_spans = []
+    named_found_features = []
     for vec_name, vec in vec_union.transformer_list:
-
         vec_prefix = '{}__'.format(vec_name)
-        # TODO - unhashed support (?)
-        transform_fw_lst = lambda fw_lst: [
-            FeatureWeight(fw.feature[len(vec_prefix):], fw.weight, fw.std)
-            for fw in fw_lst if fw.feature.startswith(vec_prefix)]
-        feature_weights = FeatureWeights(
-            pos=transform_fw_lst(all_feature_weights.pos),
-            neg=transform_fw_lst(all_feature_weights.neg),
-            pos_remaining=all_feature_weights.pos_remaining,
-            neg_remaining=all_feature_weights.neg_remaining,
+        feature_fn = lambda x: (
+            x[len(vec_prefix):] if x.startswith(vec_prefix) else None)
+        result = _get_doc_weighted_spans(doc, vec, feature_weights, feature_fn)
+        if result:
+            found_features, doc_weighted_spans = result
+            doc_weighted_spans.vec_name = vec_name
+            named_found_features.append((vec_name, found_features))
+            docs_weighted_spans.append(doc_weighted_spans)
+
+    if docs_weighted_spans:
+        return WeightedSpans(
+            docs_weighted_spans,
+            other=_get_other(feature_weights, named_found_features),
         )
-        wspans = get_weighted_spans(doc, vec, feature_weights)
-        if wspans is not None:
-            for ws in wspans:
-                if ws.vec_name is None:
-                    ws.vec_name = vec_name
-                weighted_spans.append(ws)
-
-    return weighted_spans or None
 
 
-def _get_other(feature_weights, feature_weights_dict, found_features):
+def _get_other(feature_weights, named_found_features):
+    # type: (FeatureWeights, List[Tuple[str, FoundFeatures]]) -> FeatureWeights
     # search for items that were not accounted at all.
     other_items = []
     accounted_keys = set()  # type: Set[Tuple[str, int]]
-    for feature, (_, key) in feature_weights_dict.items():
-        if key not in found_features and key not in accounted_keys:
-            group, idx = key
-            other_items.append(getattr(feature_weights, group)[idx])
-            accounted_keys.add(key)
-    if found_features:
-        other_items.append(FeatureWeight(
-            FormattedFeatureName('Highlighted in text (sum)'),
-            sum(found_features.values())))
+    all_found_features = {}
+    for _, found_features in named_found_features:
+        all_found_features.update(found_features)
+
+    for group in ['pos', 'neg']:
+        for idx, fw in enumerate(getattr(feature_weights, group)):
+            key = (group, idx)
+            if key not in all_found_features and key not in accounted_keys:
+                other_items.append(fw)
+                accounted_keys.add(key)
+
+    for vec_name, found_features in named_found_features:
+        if found_features:
+            other_items.append(FeatureWeight(
+                feature=FormattedFeatureName(
+                    '{}Highlighted in text (sum)'.format(
+                        '{}: '.format(vec_name) if vec_name else '')),
+                weight=sum(found_features.values())))
+
     other_items.sort(key=lambda x: abs(x.weight), reverse=True)
     return FeatureWeights(
         pos=[fw for fw in other_items if fw.weight >= 0],

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -60,9 +60,9 @@ def _get_doc_weighted_spans(doc, vec, feature_weights, feature_fn=None):
             found_features[key] = weight
 
     return found_features, DocWeightedSpans(
-        analyzer=vec.analyzer,
         document=preprocessed_doc,
         spans=spans,
+        preserve_density=vec.analyzer.startswith('char'),
     )
 
 

--- a/eli5/templates/weighted_spans.html
+++ b/eli5/templates/weighted_spans.html
@@ -1,12 +1,12 @@
-{% if target.weighted_spans %}
-    {# TODO - well, I don't known, merge them? #}
-    {% for weighted_spans in target.weighted_spans %}
-        {% with wts = weighted_spans.other %}
-            {% set w_range = other_weight_range %}
-            {% include "weights_table.html" with context %}
-        {% endwith %}
-    {% endfor %}
+{% if ws_other %}
+    {% with wts = ws_other %}
+        {% set w_range = other_weight_range %}
+        {% include "weights_table.html" with context %}
+    {% endwith %}
+{% endif %}
+
+{% if rendered_ws %}
     <p style="margin-bottom: 2.5em; margin-top:-0.5em;">
-        {{ rendered_weighted_spans }}
+        {{ rendered_ws }}
     </p>
 {% endif %}

--- a/eli5/templates/weighted_spans.html
+++ b/eli5/templates/weighted_spans.html
@@ -1,8 +1,11 @@
 {% if target.weighted_spans %}
-    {% with wts = target.weighted_spans.other %}
-        {% set w_range = other_weight_range %}
-        {% include "weights_table.html" with context %}
-    {% endwith %}
+    {# TODO - well, I don't known, merge them? #}
+    {% for weighted_spans in target.weighted_spans %}
+        {% with wts = weighted_spans.other %}
+            {% set w_range = other_weight_range %}
+            {% include "weights_table.html" with context %}
+        {% endwith %}
+    {% endfor %}
     <p style="margin-bottom: 2.5em; margin-top:-0.5em;">
         {{ rendered_weighted_spans }}
     </p>

--- a/eli5/templates/weights.html
+++ b/eli5/templates/weights.html
@@ -26,13 +26,13 @@
         </table>
     {% endif %}
 
-    {% for target, rendered_weighted_spans in targets_with_rendered_weighted_spans %}
+    {% for target, rendered_ws, ws_other in targets_with_weighted_spans %}
         {% include "weighted_spans.html" with context %}
     {% endfor %}
 
 {% else %}
 
-    {% for target, rendered_weighted_spans in targets_with_rendered_weighted_spans %}
+    {% for target, rendered_ws, ws_other in targets_with_weighted_spans %}
 
         {% if force_weights or not target.weighted_spans %}
             {% with wts = target.feature_weights %}

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -118,3 +118,16 @@ def _get_value_indices(names1, names2, lookups):
     positions = {name: idx for idx, name in enumerate(names2)}
     positions.update({name: idx for idx, name in enumerate(names1)})
     return [positions[name] for name in lookups]
+
+
+def max_or_0(it):
+    """
+    >>> max_or_0([])
+    0
+    >>> max_or_0(iter([]))
+    0
+    >>> max_or_0(iter([-10, -2, -11]))
+    -2
+    """
+    lst = list(it)
+    return max(lst) if lst else 0

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -97,13 +97,13 @@ def test_format_single_feature():
 
 def test_render_weighted_spans_word():
     weighted_spans = DocWeightedSpans(
-        analyzer='word',
         document='i see: a leaning lemon tree',
         spans=[
             ('see', [(2, 5)], 0.2),
             ('tree', [(23, 27)], -0.6),
             ('leaning lemon', [(9, 16), (17, 22)], 0.5),
             ('lemon tree', [(17, 22), (23, 27)], 0.8)],
+        preserve_density=False,
     )
     s = _render_weighted_spans(weighted_spans)
     assert s.startswith(
@@ -147,12 +147,12 @@ def test_render_weighted_spans_word():
 
 def test_render_weighted_spans_char():
     weighted_spans = DocWeightedSpans(
-        analyzer='char',
         document='see',
         spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
             ],
+        preserve_density=True,
     )
     s = _render_weighted_spans(weighted_spans)
     assert s == (
@@ -170,12 +170,12 @@ def test_render_weighted_spans_char():
 
 def test_override_preserve_density():
     weighted_spans = DocWeightedSpans(
-        analyzer='char',
         document='see',
         spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
         ],
+        preserve_density=True,
     )
     s = _render_weighted_spans(weighted_spans, preserve_density=False)
     assert s.startswith(

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -10,16 +10,18 @@ from eli5.formatters import (
     format_as_text, format_as_html, format_html_styles, FormattedFeatureName)
 from eli5.formatters.html import (
     _format_unhashed_feature, render_weighted_spans, _format_single_feature,
-    _format_feature, remaining_weight_color_hsl, weight_color_hsl,
-    get_char_weights)
+    _format_feature, remaining_weight_color_hsl, weight_color_hsl)
+from eli5.formatters.text_helpers import get_char_weights, PreparedWeightedSpans
 from .utils import write_html
 
 
-def _render_weighted_spans(weighted_spans_data, preserve_density=None):
-    char_weights = get_char_weights(weighted_spans_data, preserve_density)
+def _render_weighted_spans(weighted_spans, preserve_density=None):
+    char_weights = get_char_weights(weighted_spans, preserve_density)
     weight_range = max(abs(x) for x in char_weights)
-    return render_weighted_spans(
-        weighted_spans_data.document, char_weights, weight_range)
+    return render_weighted_spans(PreparedWeightedSpans(
+        weighted_spans=weighted_spans,
+        char_weights=char_weights,
+        weight_range=weight_range))
 
 
 def test_render_styles():

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -4,7 +4,7 @@ import pytest
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 
-from eli5.base import WeightedSpans, FeatureWeight
+from eli5.base import DocWeightedSpans, FeatureWeight
 from eli5 import explain_weights_sklearn, explain_prediction_sklearn
 from eli5.formatters import (
     format_as_text, format_as_html, format_html_styles, FormattedFeatureName)
@@ -15,11 +15,11 @@ from eli5.formatters.text_helpers import get_char_weights, PreparedWeightedSpans
 from .utils import write_html
 
 
-def _render_weighted_spans(weighted_spans, preserve_density=None):
-    char_weights = get_char_weights(weighted_spans, preserve_density)
+def _render_weighted_spans(doc_weighted_spans, preserve_density=None):
+    char_weights = get_char_weights(doc_weighted_spans, preserve_density)
     weight_range = max(abs(x) for x in char_weights)
     return render_weighted_spans(PreparedWeightedSpans(
-        weighted_spans=weighted_spans,
+        doc_weighted_spans,
         char_weights=char_weights,
         weight_range=weight_range))
 
@@ -96,10 +96,10 @@ def test_format_single_feature():
 
 
 def test_render_weighted_spans_word():
-    weighted_spans = WeightedSpans(
+    weighted_spans = DocWeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
-        weighted_spans=[
+        spans=[
             ('see', [(2, 5)], 0.2),
             ('tree', [(23, 27)], -0.6),
             ('leaning lemon', [(9, 16), (17, 22)], 0.5),
@@ -146,10 +146,10 @@ def test_render_weighted_spans_word():
 
 
 def test_render_weighted_spans_char():
-    weighted_spans = WeightedSpans(
+    weighted_spans = DocWeightedSpans(
         analyzer='char',
         document='see',
-        weighted_spans=[
+        spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
             ],
@@ -169,10 +169,10 @@ def test_render_weighted_spans_char():
 
 
 def test_override_preserve_density():
-    weighted_spans = WeightedSpans(
+    weighted_spans = DocWeightedSpans(
         analyzer='char',
         document='see',
-        weighted_spans=[
+        spans=[
             ('se', [(0, 2)], 0.2),
             ('ee', [(1, 3)], 0.1),
         ],

--- a/tests/test_formatters_text_helpers.py
+++ b/tests/test_formatters_text_helpers.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from eli5.base import (
-    TargetExplanation, WeightedSpans, FeatureWeights)
+    TargetExplanation, WeightedSpans, DocWeightedSpans, FeatureWeights)
 from eli5.formatters.text_helpers import (
     PreparedWeightedSpans, prepare_weighted_spans)
 
@@ -11,64 +11,64 @@ def test_prepare_weighted_spans():
         TargetExplanation(
             target='one',
             feature_weights=FeatureWeights(pos=[], neg=[]),
-            weighted_spans=[
-                WeightedSpans(
-                    analyzer='char',
-                    document='ab',
-                    weighted_spans=[
-                        ('a', [(0, 1)], 1.5),
-                        ('b', [(1, 2)], 2.5),
-                    ],
-                ),
-                WeightedSpans(
-                    analyzer='char',
-                    document='xy',
-                    weighted_spans=[
-                        ('xy', [(0, 2)], -4.5),
-                    ],
-                ),
-            ],
-        ),
+            weighted_spans=WeightedSpans(
+                docs_weighted_spans=[
+                    DocWeightedSpans(
+                        analyzer='char',
+                        document='ab',
+                        spans=[
+                            ('a', [(0, 1)], 1.5),
+                            ('b', [(1, 2)], 2.5),
+                        ],
+                    ),
+                    DocWeightedSpans(
+                        analyzer='char',
+                        document='xy',
+                        spans=[
+                            ('xy', [(0, 2)], -4.5),
+                        ],
+                    )]
+            )),
         TargetExplanation(
             target='two',
             feature_weights=FeatureWeights(pos=[], neg=[]),
-            weighted_spans=[
-                WeightedSpans(
-                    analyzer='char',
-                    document='abc',
-                    weighted_spans=[
-                        ('a', [(0, 1)], 0.5),
-                        ('c', [(2, 3)], 3.5),
-                    ],
-                ),
-                WeightedSpans(
-                    analyzer='char',
-                    document='xz',
-                    weighted_spans=[
-                        ('xz', [(0, 2)], 1.5),
-                    ],
-                ),
-            ],
-        ),
+            weighted_spans=WeightedSpans(
+                docs_weighted_spans=[
+                    DocWeightedSpans(
+                        analyzer='char',
+                        document='abc',
+                        spans=[
+                            ('a', [(0, 1)], 0.5),
+                            ('c', [(2, 3)], 3.5),
+                        ],
+                    ),
+                    DocWeightedSpans(
+                        analyzer='char',
+                        document='xz',
+                        spans=[
+                            ('xz', [(0, 2)], 1.5),
+                        ],
+                    )],
+            )),
     ]
     assert prepare_weighted_spans(targets, preserve_density=False) == [
         [
             PreparedWeightedSpans(
-                weighted_spans=targets[0].weighted_spans[0],
+                targets[0].weighted_spans.docs_weighted_spans[0],
                 char_weights=np.array([1.5, 2.5]),
                 weight_range=3.5),
             PreparedWeightedSpans(
-                weighted_spans=targets[0].weighted_spans[1],
+                targets[0].weighted_spans.docs_weighted_spans[1],
                 char_weights=np.array([-4.5, -4.5]),
                 weight_range=4.5),
         ],
         [
             PreparedWeightedSpans(
-                weighted_spans=targets[1].weighted_spans[0],
+                targets[1].weighted_spans.docs_weighted_spans[0],
                 char_weights=np.array([0.5, 0, 3.5]),
                 weight_range=3.5),
             PreparedWeightedSpans(
-                weighted_spans=targets[1].weighted_spans[1],
+                targets[1].weighted_spans.docs_weighted_spans[1],
                 char_weights=np.array([1.5, 1.5]),
                 weight_range=4.5),
         ],

--- a/tests/test_formatters_text_helpers.py
+++ b/tests/test_formatters_text_helpers.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from eli5.base import (
+    TargetExplanation, WeightedSpans, FeatureWeights)
+from eli5.formatters.text_helpers import (
+    PreparedWeightedSpans, prepare_weighted_spans)
+
+
+def test_prepare_weighted_spans():
+    targets = [
+        TargetExplanation(
+            target='one',
+            feature_weights=FeatureWeights(pos=[], neg=[]),
+            weighted_spans=[
+                WeightedSpans(
+                    analyzer='char',
+                    document='ab',
+                    weighted_spans=[
+                        ('a', [(0, 1)], 1.5),
+                        ('b', [(1, 2)], 2.5),
+                    ],
+                ),
+                WeightedSpans(
+                    analyzer='char',
+                    document='xy',
+                    weighted_spans=[
+                        ('xy', [(0, 2)], -4.5),
+                    ],
+                ),
+            ],
+        ),
+        TargetExplanation(
+            target='two',
+            feature_weights=FeatureWeights(pos=[], neg=[]),
+            weighted_spans=[
+                WeightedSpans(
+                    analyzer='char',
+                    document='abc',
+                    weighted_spans=[
+                        ('a', [(0, 1)], 0.5),
+                        ('c', [(2, 3)], 3.5),
+                    ],
+                ),
+                WeightedSpans(
+                    analyzer='char',
+                    document='xz',
+                    weighted_spans=[
+                        ('xz', [(0, 2)], 1.5),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    assert prepare_weighted_spans(targets, preserve_density=False) == [
+        [
+            PreparedWeightedSpans(
+                weighted_spans=targets[0].weighted_spans[0],
+                char_weights=np.array([1.5, 2.5]),
+                weight_range=3.5),
+            PreparedWeightedSpans(
+                weighted_spans=targets[0].weighted_spans[1],
+                char_weights=np.array([-4.5, -4.5]),
+                weight_range=4.5),
+        ],
+        [
+            PreparedWeightedSpans(
+                weighted_spans=targets[1].weighted_spans[0],
+                char_weights=np.array([0.5, 0, 3.5]),
+                weight_range=3.5),
+            PreparedWeightedSpans(
+                weighted_spans=targets[1].weighted_spans[1],
+                char_weights=np.array([1.5, 1.5]),
+                weight_range=4.5),
+        ],
+    ]

--- a/tests/test_formatters_text_helpers.py
+++ b/tests/test_formatters_text_helpers.py
@@ -14,7 +14,6 @@ def test_prepare_weighted_spans():
             weighted_spans=WeightedSpans(
                 docs_weighted_spans=[
                     DocWeightedSpans(
-                        analyzer='char',
                         document='ab',
                         spans=[
                             ('a', [(0, 1)], 1.5),
@@ -22,7 +21,6 @@ def test_prepare_weighted_spans():
                         ],
                     ),
                     DocWeightedSpans(
-                        analyzer='char',
                         document='xy',
                         spans=[
                             ('xy', [(0, 2)], -4.5),
@@ -35,7 +33,6 @@ def test_prepare_weighted_spans():
             weighted_spans=WeightedSpans(
                 docs_weighted_spans=[
                     DocWeightedSpans(
-                        analyzer='char',
                         document='abc',
                         spans=[
                             ('a', [(0, 1)], 0.5),
@@ -43,7 +40,6 @@ def test_prepare_weighted_spans():
                         ],
                     ),
                     DocWeightedSpans(
-                        analyzer='char',
                         document='xz',
                         spans=[
                             ('xz', [(0, 2)], 1.5),

--- a/tests/test_sklearn_text.py
+++ b/tests/test_sklearn_text.py
@@ -19,7 +19,7 @@ def test_weighted_spans_word():
             neg=[FW('tree', -6)],
             neg_remaining=10
         ))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -30,7 +30,7 @@ def test_weighted_spans_word():
             pos=[FW('bias', 8), FW(hl_in_text, 0)],
             neg=[],
             neg_remaining=10,
-        ))
+        ))]
 
 
 def test_weighted_spans_word_bigrams():
@@ -42,7 +42,7 @@ def test_weighted_spans_word_bigrams():
         FeatureWeights(
             pos=[FW('see', 2), FW('leaning lemon', 5), FW('lemon tree', 8)],
             neg=[FW('tree', -6)]))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -53,7 +53,7 @@ def test_weighted_spans_word_bigrams():
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
             neg=[],
-        ))
+        ))]
 
 
 def test_weighted_spans_word_stopwords():
@@ -65,7 +65,7 @@ def test_weighted_spans_word_stopwords():
         FeatureWeights(
             pos=[FW('see', 2), FW('lemon', 5), FW('bias', 8)],
             neg=[FW('tree', -6)]))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='word',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -74,7 +74,7 @@ def test_weighted_spans_word_stopwords():
         other=FeatureWeights(
             pos=[FW('bias', 8), FW('see', 2)],
             neg=[FW(hl_in_text, -1)],
-        ))
+        ))]
 
 
 def test_weighted_spans_char():
@@ -86,7 +86,7 @@ def test_weighted_spans_char():
         FeatureWeights(
             pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
             neg=[FW('lem', -6)]))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='char',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -97,7 +97,7 @@ def test_weighted_spans_char():
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
             neg=[],
-        ))
+        ))]
 
 
 def test_no_weighted_spans():
@@ -105,11 +105,11 @@ def test_no_weighted_spans():
     vec = CountVectorizer(analyzer='char', ngram_range=(3, 4))
     vec.fit([doc])
     w_spans = get_weighted_spans(doc, vec, FeatureWeights(pos=[], neg=[]))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='char',
         document='i see: a leaning lemon tree',
         weighted_spans=[],
-        other=FeatureWeights(pos=[], neg=[]))
+        other=FeatureWeights(pos=[], neg=[]))]
 
 
 def test_weighted_spans_char_wb():
@@ -121,7 +121,7 @@ def test_weighted_spans_char_wb():
         FeatureWeights(
             pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
             neg=[FW('lem', -6), FW(' lem', -4)]))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='char_wb',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -132,7 +132,7 @@ def test_weighted_spans_char_wb():
         other=FeatureWeights(
             pos=[FW('a le', 5), FW(hl_in_text, 0)],
             neg=[],
-        ))
+        ))]
 
 
 def test_unhashed_features_other():
@@ -154,7 +154,7 @@ def test_unhashed_features_other():
                 FW([{'name': 'ree', 'sign': 1}, {'name': 'tre', 'sign': 1}], -4),
             ],
         ))
-    assert w_spans == WeightedSpans(
+    assert w_spans == [WeightedSpans(
         analyzer='char',
         document='i see: a leaning lemon tree',
         weighted_spans=[
@@ -167,4 +167,4 @@ def test_unhashed_features_other():
                 FW([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
             neg=[FW(hl_in_text, -2)],
-        ))
+        ))]

--- a/tests/test_sklearn_text.py
+++ b/tests/test_sklearn_text.py
@@ -9,9 +9,6 @@ from eli5.sklearn.text import get_weighted_spans
 hl_in_text = FormattedFeatureName('Highlighted in text (sum)')
 
 
-# TODO - test for FeatureUnion
-
-
 def test_weighted_spans_word():
     doc = 'I see: a leaning lemon tree'
     vec = CountVectorizer(analyzer='word')
@@ -25,12 +22,12 @@ def test_weighted_spans_word():
         ))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='word',
             document='i see: a leaning lemon tree',
             spans=[
                 ('see', [(2, 5)], 2),
                 ('lemon', [(17, 22)], 4),
                 ('tree', [(23, 27)], -6)],
+            preserve_density=False,
         )],
         other=FeatureWeights(
             pos=[FW('bias', 8), FW(hl_in_text, 0)],
@@ -50,13 +47,13 @@ def test_weighted_spans_word_bigrams():
             neg=[FW('tree', -6)]))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='word',
             document='i see: a leaning lemon tree',
             spans=[
                 ('see', [(2, 5)], 2),
                 ('tree', [(23, 27)], -6),
                 ('leaning lemon', [(9, 16), (17, 22)], 5),
                 ('lemon tree', [(17, 22), (23, 27)], 8)],
+            preserve_density=False,
         )],
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
@@ -75,11 +72,11 @@ def test_weighted_spans_word_stopwords():
             neg=[FW('tree', -6)]))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='word',
             document='i see: a leaning lemon tree',
             spans=[
                 ('lemon', [(17, 22)], 5),
                 ('tree', [(23, 27)], -6)],
+            preserve_density=False,
         )],
         other=FeatureWeights(
             pos=[FW('bias', 8), FW('see', 2)],
@@ -98,13 +95,13 @@ def test_weighted_spans_char():
             neg=[FW('lem', -6)]))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='char',
             document='i see: a leaning lemon tree',
             spans=[
                 ('see', [(2, 5)], 2),
                 ('lem', [(17, 20)], -6),
                 ('on ', [(20, 23)], 8),
                 ('a le', [(7, 11)], 5)],
+            preserve_density=True,
         )],
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
@@ -119,9 +116,9 @@ def test_no_weighted_spans():
     w_spans = get_weighted_spans(doc, vec, FeatureWeights(pos=[], neg=[]))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='char',
             document='i see: a leaning lemon tree',
             spans=[],
+            preserve_density=True,
         )],
         other=FeatureWeights(pos=[], neg=[]))
 
@@ -137,13 +134,13 @@ def test_weighted_spans_char_wb():
             neg=[FW('lem', -6), FW(' lem', -4)]))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='char_wb',
             document='i see: a leaning lemon tree',
             spans=[
                 ('see', [(2, 5)], 2),
                 ('lem', [(17, 20)], -6),
                 ('on ', [(20, 23)], 8),
                 (' lem', [(16, 20)], -4)],
+            preserve_density=True,
         )],
         other=FeatureWeights(
             pos=[FW('a le', 5), FW(hl_in_text, 0)],
@@ -172,13 +169,13 @@ def test_unhashed_features_other():
         ))
     assert w_spans == WeightedSpans(
         [DocWeightedSpans(
-            analyzer='char',
             document='i see: a leaning lemon tree',
             spans=[
                 ('see', [(2, 5)], 2),
                 ('tre', [(23, 26)], -4),
                 ('ree', [(24, 27)], -4),
                 ],
+            preserve_density=True,
         )],
         other=FeatureWeights(
             pos=[

--- a/tests/test_sklearn_text.py
+++ b/tests/test_sklearn_text.py
@@ -1,11 +1,15 @@
 from sklearn.feature_extraction.text import CountVectorizer
 
-from eli5.base import WeightedSpans, FeatureWeights, FeatureWeight as FW
+from eli5.base import (
+    DocWeightedSpans, WeightedSpans, FeatureWeights, FeatureWeight as FW)
 from eli5.formatters import FormattedFeatureName
 from eli5.sklearn.text import get_weighted_spans
 
 
 hl_in_text = FormattedFeatureName('Highlighted in text (sum)')
+
+
+# TODO - test for FeatureUnion
 
 
 def test_weighted_spans_word():
@@ -19,18 +23,20 @@ def test_weighted_spans_word():
             neg=[FW('tree', -6)],
             neg_remaining=10
         ))
-    assert w_spans == [WeightedSpans(
-        analyzer='word',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('see', [(2, 5)], 2),
-            ('lemon', [(17, 22)], 4),
-            ('tree', [(23, 27)], -6)],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='word',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('see', [(2, 5)], 2),
+                ('lemon', [(17, 22)], 4),
+                ('tree', [(23, 27)], -6)],
+        )],
         other=FeatureWeights(
             pos=[FW('bias', 8), FW(hl_in_text, 0)],
             neg=[],
             neg_remaining=10,
-        ))]
+        ))
 
 
 def test_weighted_spans_word_bigrams():
@@ -42,18 +48,20 @@ def test_weighted_spans_word_bigrams():
         FeatureWeights(
             pos=[FW('see', 2), FW('leaning lemon', 5), FW('lemon tree', 8)],
             neg=[FW('tree', -6)]))
-    assert w_spans == [WeightedSpans(
-        analyzer='word',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('see', [(2, 5)], 2),
-            ('tree', [(23, 27)], -6),
-            ('leaning lemon', [(9, 16), (17, 22)], 5),
-            ('lemon tree', [(17, 22), (23, 27)], 8)],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='word',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('see', [(2, 5)], 2),
+                ('tree', [(23, 27)], -6),
+                ('leaning lemon', [(9, 16), (17, 22)], 5),
+                ('lemon tree', [(17, 22), (23, 27)], 8)],
+        )],
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
             neg=[],
-        ))]
+        ))
 
 
 def test_weighted_spans_word_stopwords():
@@ -65,16 +73,18 @@ def test_weighted_spans_word_stopwords():
         FeatureWeights(
             pos=[FW('see', 2), FW('lemon', 5), FW('bias', 8)],
             neg=[FW('tree', -6)]))
-    assert w_spans == [WeightedSpans(
-        analyzer='word',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('lemon', [(17, 22)], 5),
-            ('tree', [(23, 27)], -6)],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='word',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('lemon', [(17, 22)], 5),
+                ('tree', [(23, 27)], -6)],
+        )],
         other=FeatureWeights(
             pos=[FW('bias', 8), FW('see', 2)],
             neg=[FW(hl_in_text, -1)],
-        ))]
+        ))
 
 
 def test_weighted_spans_char():
@@ -86,18 +96,20 @@ def test_weighted_spans_char():
         FeatureWeights(
             pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
             neg=[FW('lem', -6)]))
-    assert w_spans == [WeightedSpans(
-        analyzer='char',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('see', [(2, 5)], 2),
-            ('lem', [(17, 20)], -6),
-            ('on ', [(20, 23)], 8),
-            ('a le', [(7, 11)], 5)],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='char',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('see', [(2, 5)], 2),
+                ('lem', [(17, 20)], -6),
+                ('on ', [(20, 23)], 8),
+                ('a le', [(7, 11)], 5)],
+        )],
         other=FeatureWeights(
             pos=[FW(hl_in_text, 9)],
             neg=[],
-        ))]
+        ))
 
 
 def test_no_weighted_spans():
@@ -105,11 +117,13 @@ def test_no_weighted_spans():
     vec = CountVectorizer(analyzer='char', ngram_range=(3, 4))
     vec.fit([doc])
     w_spans = get_weighted_spans(doc, vec, FeatureWeights(pos=[], neg=[]))
-    assert w_spans == [WeightedSpans(
-        analyzer='char',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[],
-        other=FeatureWeights(pos=[], neg=[]))]
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='char',
+            document='i see: a leaning lemon tree',
+            spans=[],
+        )],
+        other=FeatureWeights(pos=[], neg=[]))
 
 
 def test_weighted_spans_char_wb():
@@ -121,18 +135,20 @@ def test_weighted_spans_char_wb():
         FeatureWeights(
             pos=[FW('see', 2), FW('a le', 5), FW('on ', 8)],
             neg=[FW('lem', -6), FW(' lem', -4)]))
-    assert w_spans == [WeightedSpans(
-        analyzer='char_wb',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('see', [(2, 5)], 2),
-            ('lem', [(17, 20)], -6),
-            ('on ', [(20, 23)], 8),
-            (' lem', [(16, 20)], -4)],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='char_wb',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('see', [(2, 5)], 2),
+                ('lem', [(17, 20)], -6),
+                ('on ', [(20, 23)], 8),
+                (' lem', [(16, 20)], -4)],
+        )],
         other=FeatureWeights(
             pos=[FW('a le', 5), FW(hl_in_text, 0)],
             neg=[],
-        ))]
+        ))
 
 
 def test_unhashed_features_other():
@@ -154,17 +170,19 @@ def test_unhashed_features_other():
                 FW([{'name': 'ree', 'sign': 1}, {'name': 'tre', 'sign': 1}], -4),
             ],
         ))
-    assert w_spans == [WeightedSpans(
-        analyzer='char',
-        document='i see: a leaning lemon tree',
-        weighted_spans=[
-            ('see', [(2, 5)], 2),
-            ('tre', [(23, 26)], -4),
-            ('ree', [(24, 27)], -4),
-            ],
+    assert w_spans == WeightedSpans(
+        [DocWeightedSpans(
+            analyzer='char',
+            document='i see: a leaning lemon tree',
+            spans=[
+                ('see', [(2, 5)], 2),
+                ('tre', [(23, 26)], -4),
+                ('ree', [(24, 27)], -4),
+                ],
+        )],
         other=FeatureWeights(
             pos=[
                 FW([{'name': 'zoo', 'sign': 1}, {'name': 'bar', 'sign': 1}], 3),
             ],
             neg=[FW(hl_in_text, -2)],
-        ))]
+        ))

--- a/tests/test_sklearn_vectorizers.py
+++ b/tests/test_sklearn_vectorizers.py
@@ -11,6 +11,7 @@ from sklearn.feature_extraction import DictVectorizer
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import FeatureUnion
 
 from eli5 import explain_prediction
 from .utils import format_as_all, get_all_features, get_names_coefs
@@ -159,3 +160,38 @@ def test_explain_regression_hashing_vectorizer(newsgroups_train_binary):
         for (name, coef), (count_name, count_coef) in zip(values, count_values):
             assert name == count_name
             assert abs(coef - count_coef) < 0.05
+
+
+@pytest.mark.parametrize(['vec_cls'], [
+    [CountVectorizer],
+   #[HashingVectorizer],
+])
+def test_explain_feature_union(vec_cls):
+    data = [
+        {'url': 'http://a.com/blog',
+         'text': 'security research'},
+        {'url': 'http://a.com',
+         'text': 'security research'},
+        {'url': 'http://b.com/blog',
+         'text': 'health study'},
+        {'url': 'http://b.com',
+         'text': 'health research'},
+        {'url': 'http://c.com/blog',
+         'text': 'security'},
+        ]
+    ys = [1, 0, 0, 0, 1]
+    vec = FeatureUnion([
+        ('url', vec_cls(preprocessor=lambda x: x['url'],
+                        analyzer='char',
+                        ngram_range=(3, 3))),
+        ('text', vec_cls(preprocessor=lambda x: x['text'])),
+    ])
+    xs = vec.fit_transform(data)
+    clf = LogisticRegression(random_state=42)
+    clf.fit(xs, ys)
+    res = explain_prediction(clf, data[0], vec)
+    _, html_expl = format_as_all(res, clf)
+    assert 'text: Highlighted in text (sum)' in html_expl
+    assert 'url: Highlighted in text (sum)' in html_expl
+    assert '<b>url:</b> <span' in html_expl
+    assert '<b>text:</b> <span' in html_expl

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ def format_as_all(res, clf, **kwargs):
     expl_text = format_as_text(res, **kwargs)
     expl_html = format_as_html(res, **kwargs)
     print(expl_text)
-    write_html(clf, expl_html, expl_text)
+    write_html(clf, expl_html, expl_text, caller_depth=2)
     return expl_text, expl_html
 
 
@@ -39,12 +39,12 @@ def strip_blanks(html):
     return html.replace(' ', '').replace('\n', '')
 
 
-def write_html(clf, html, text, postfix=''):
+def write_html(clf, html, text, postfix='', caller_depth=1):
     """ Write to html file in .html directory. Filename is generated from calling
     function name and module, and clf class name.
     This is useful to check and debug format_as_html function.
     """
-    caller = inspect.stack()[2]
+    caller = inspect.stack()[caller_depth]
     try:
         test_name, test_file = caller.function, caller.filename
     except AttributeError:


### PR DESCRIPTION
The approach is to highlight features for each of the vectorizers of the FeatureUnion, then render them and merge results.

TODO:

- [x] the bias term is not displayed for some reason
- [x] ~check (and test) support for unhashed features: something might be missing at the moment~ they don't work and I'd like to do it in a separate PR
- [x] tests for FeatureUnion, including cases of mixing text and non-text vectorizers
