### PR TITLE
Fix target header in horizontal layout

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -48,6 +48,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         highlight_spaces = should_highlight_spaces(explanation)
 
     targets = explanation.targets or []
+    if len(targets) == 1:
+        horizontal_layout = False
 
     any_weighted_spans = any(t.weighted_spans for t in targets)
     spans_char_weights = [
@@ -63,10 +65,14 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         if t.weighted_spans else None
         for t, char_weights in zip(targets, spans_char_weights)]
 
+    target_table_styles = 'border-collapse: collapse; border: none;'
+    if horizontal_layout:
+        target_table_styles += ' width: 100%;'
+
     return template.render(
         include_styles=include_styles,
         force_weights=force_weights,
-        table_styles='border-collapse: collapse; border: none;',
+        target_table_styles=target_table_styles,
         tr_styles='border: none;',
         td1_styles='padding: 0 1em 0 0.5em; text-align: right; border: none;',
         tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none;',
@@ -75,8 +81,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         'border-collapse: collapse; border: none;',
         horizontal_layout_td_styles=
         'padding: 0px; border: 1px solid black; vertical-align: top;',
-        tddm_header_styles='text-align: center; padding: 0.5em; '
-                           'border: none; border-bottom: 1px solid black;',
+        horizontal_layout_header_styles=
+        'padding: 0.5em; border: 1px solid black; text-align: center;',
         show=show,
         expl=explanation,
         hl_spaces=highlight_spaces,

--- a/eli5/templates/weights.html
+++ b/eli5/templates/weights.html
@@ -1,14 +1,20 @@
-{% if horizontal_layout and expl.targets|length > 1 %}
+{% if horizontal_layout %}
 
     {% if force_weights or not any_weighted_spans %}
         <table class="eli5-weights-wrapper" style="{{ horizontal_layout_table_styles }}">
+            <tr>
+                {% for target in expl.targets %}
+                    <td style="{{ horizontal_layout_header_styles }}">
+                        {% include "target_header.html" with context %}
+                    </td>
+                {% endfor %}
+            </tr>
             <tr>
                 {% with w_range = target_weight_range %}
                     {% for target in expl.targets %}
                         <td style="{{ horizontal_layout_td_styles }}">
                             {% if force_weights or not target.weighted_spans %}
                                 {% with wts = target.feature_weights %}
-                                    {% set inline_target_header = True %}
                                     {% include "weights_table.html" with context %}
                                 {% endwith %}
                             {% endif %}
@@ -29,7 +35,6 @@
 
         {% if force_weights or not target.weighted_spans %}
             {% with wts = target.feature_weights %}
-                {% set inline_target_header = False %}
                 {% set w_range = target_weight_range %}
                 {% include "weights_table.html" with context %}
             {% endwith %}

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -1,20 +1,13 @@
 {% if wts.pos or wts.neg or wts.neg_remaining or wts.pos_remaining %}
 
-    {% if not inline_target_header %}
+    {% if not horizontal_layout %}
         <p>
             {% include "target_header.html" with context %}
         </p>
     {% endif %}
 
-    <table class="eli5-weights" style="{{ table_styles }}">
+    <table class="eli5-weights" style="{{ target_table_styles }}">
         <thead>
-        {% if inline_target_header %}
-            <tr style="{{ tr_styles }}">
-                <td colspan="2" style="{{ tddm_header_styles }}">
-                    {% include "target_header.html" with context %}
-                </td>
-            </tr>
-        {% endif %}
         <tr style="{{ tr_styles }}">
             <th style="{{ td1_styles }}">Weight</th>
             <th style="{{ td2_styles }}">Feature</th>


### PR DESCRIPTION
Move it to the outer table, so it is aligned across all targets. Fixes #99 - this is how it looks now in case targets don't fit in one line:
![2016-11-23 15 49 23](https://cloud.githubusercontent.com/assets/424613/20562672/db508042-b195-11e6-815d-efe1c453c765.png)
