### PR TITLE
Fix horizontal layout (broken in #103)

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -65,14 +65,11 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         if t.weighted_spans else None
         for t, char_weights in zip(targets, spans_char_weights)]
 
-    target_table_styles = 'border-collapse: collapse; border: none;'
-    if horizontal_layout:
-        target_table_styles += ' width: 100%;'
 
     return template.render(
         include_styles=include_styles,
         force_weights=force_weights,
-        target_table_styles=target_table_styles,
+        target_table_styles='border-collapse: collapse; border: none;',
         tr_styles='border: none;',
         td1_styles='padding: 0 1em 0 0.5em; text-align: right; border: none;',
         tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none;',

--- a/eli5/templates/weights.html
+++ b/eli5/templates/weights.html
@@ -15,6 +15,7 @@
                         <td style="{{ horizontal_layout_td_styles }}">
                             {% if force_weights or not target.weighted_spans %}
                                 {% with wts = target.feature_weights %}
+                                    {% set in_horizontal_layout = True %}
                                     {% include "weights_table.html" with context %}
                                 {% endwith %}
                             {% endif %}

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -1,12 +1,13 @@
 {% if wts.pos or wts.neg or wts.neg_remaining or wts.pos_remaining %}
 
-    {% if not horizontal_layout %}
+    {% if not in_horizontal_layout %}
         <p>
             {% include "target_header.html" with context %}
         </p>
     {% endif %}
 
-    <table class="eli5-weights" style="{{ target_table_styles }}">
+    <table class="eli5-weights"
+           style="{{ target_table_styles }}{% if in_horizontal_layout %} width: 100%;{% endif %}">
         <thead>
         <tr style="{{ tr_styles }}">
             <th style="{{ td1_styles }}">Weight</th>


### PR DESCRIPTION
The same table is used for target weights (and might be in horizontal layout) and for weights that are not highlighted in text.