### PR TITLE
OneVsRestClassifier support for explain_weights

### DIFF
--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -6,6 +6,7 @@ from lightning.impl.base import BaseEstimator
 from lightning import classification, regression
 from sklearn.multiclass import OneVsRestClassifier
 
+from eli5.base import Explanation
 from eli5.sklearn import (
     explain_linear_classifier_weights,
     explain_linear_regressor_weights,
@@ -21,10 +22,10 @@ def explain_weights_lightning(estimator, vec=None, top=20, target_names=None,
                               targets=None, feature_names=None,
                               coef_scale=None):
     """ Return an explanation of a lightning estimator weights """
-    return {
-        "estimator": repr(estimator),
-        "description": "Error: estimator %r is not supported" % estimator,
-    }
+    return Explanation(
+        estimator=repr(estimator),
+        description="Error: estimator %r is not supported" % estimator,
+    )
 
 
 @explain_prediction.register(BaseEstimator)
@@ -34,10 +35,10 @@ def explain_prediction_lightning(estimator, doc, vec=None, top=None,
                                  feature_names=None, vectorized=False,
                                  coef_scale=None):
     """ Return an explanation of a lightning estimator predictions """
-    return {
-        "estimator": repr(estimator),
-        "description": "Error: estimator %r is not supported" % estimator,
-    }
+    return Explanation(
+        estimator=repr(estimator),
+        description="Error: estimator %r is not supported" % estimator,
+    )
 
 
 @explain_prediction_lightning.register(OneVsRestClassifier)

--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -42,12 +42,21 @@ def explain_prediction_lightning(estimator, doc, vec=None, top=None,
 
 
 @explain_prediction_lightning.register(OneVsRestClassifier)
-def explain_prediction_multiclass_strategy_lightning(clf, doc, **kwargs):
+def explain_prediction_ovr_lightning(clf, doc, **kwargs):
     # dispatch OvR to eli5.lightning
     # if explain_prediction_lightning is called explicitly
     estimator = clf.estimator
     func = explain_prediction_lightning.dispatch(estimator.__class__)
     return func(clf, doc, **kwargs)
+
+
+@explain_weights_lightning.register(OneVsRestClassifier)
+def explain_weights_ovr_lightning(ovr, **kwargs):
+    # dispatch OvR to eli5.lightning
+    # if explain_weights_lightning is called explicitly
+    estimator = ovr.estimator
+    func = explain_weights_lightning.dispatch(estimator.__class__)
+    return func(ovr, **kwargs)
 
 
 _CLASSIFIERS = [

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -19,6 +19,7 @@ from sklearn.linear_model import (
     SGDClassifier,
     SGDRegressor,
 )
+from sklearn.multiclass import OneVsRestClassifier
 from sklearn.svm import LinearSVC, LinearSVR
 # TODO: see https://github.com/scikit-learn/scikit-learn/pull/2250
 from sklearn.naive_bayes import BernoulliNB, MultinomialNB
@@ -105,6 +106,22 @@ def explain_weights_sklearn(estimator, vec=None, top=_TOP,
         estimator=repr(estimator),
         error="estimator %r is not supported" % estimator,
     )
+
+
+@explain_weights.register(OneVsRestClassifier)
+def explain_weights_ovr(ovr, **kwargs):
+    estimator = ovr.estimator
+    func = explain_weights.dispatch(estimator.__class__)
+    return func(ovr, **kwargs)
+
+
+@explain_weights_sklearn.register(OneVsRestClassifier)
+def explain_weights_ovr_sklearn(ovr, **kwargs):
+    # dispatch OvR to eli5.sklearn
+    # if explain_prediction_sklearn is called explicitly
+    estimator = ovr.estimator
+    func = explain_weights_sklearn.dispatch(estimator.__class__)
+    return func(ovr, **kwargs)
 
 
 @explain_weights_sklearn.register(LogisticRegression)

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -138,13 +138,15 @@ def get_coef(clf, label_id, scale=None):
 
 def get_num_features(clf):
     """ Return size of a feature vector classifier expects as an input. """
-    if hasattr(clf, 'coef_'):
+    if hasattr(clf, 'coef_'):  # linear models
         return clf.coef_.shape[-1]
-    elif hasattr(clf, 'feature_importances_'):
+    elif hasattr(clf, 'feature_importances_'):  # ensebles
         return clf.feature_importances_.shape[-1]
-    elif hasattr(clf, 'feature_count_'):
+    elif hasattr(clf, 'feature_count_'):  # naive bayes
         return clf.feature_count_.shape[-1]
     elif hasattr(clf, 'theta_'):
         return clf.theta_.shape[-1]
+    elif hasattr(clf, 'estimators_') and len(clf.estimators_):  # OvR
+        return get_num_features(clf.estimators_[0])
     else:
         raise ValueError("Can't figure out feature vector size for %s" % clf)

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -40,7 +40,14 @@ def is_probabilistic_classifier(clf):
 def has_intercept(estimator):
     # type: (Any) -> bool
     """ Return True if an estimator has intercept fit. """
-    return getattr(estimator, 'fit_intercept', False)
+    if hasattr(estimator, 'fit_intercept'):
+        return estimator.fit_intercept
+    if hasattr(estimator, 'intercept_'):
+        if estimator.intercept_ is None:
+            return False
+        # scikit-learn sets intercept to zero vector if it is not fit
+        return np.any(estimator.intercept_)
+    return False
 
 
 def get_feature_names(clf, vec=None, bias_name='<BIAS>', feature_names=None):

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -13,20 +13,38 @@ from .test_sklearn_explain_prediction import (
     assert_multiclass_linear_classifier_explained,
     assert_linear_regression_explained,
 )
+from .test_sklearn_explain_weights import (
+    assert_explained_weights_linear_classifier,
+    assert_explained_weights_linear_regressor,
+)
 
 
 @pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
-def test_explain_classifiers(newsgroups_train, clf):
+def test_explain_predition_classifiers(newsgroups_train, clf):
     clf = OneVsRestClassifier(clf)
     assert_multiclass_linear_classifier_explained(newsgroups_train, clf,
                                                   explain_prediction)
 
 
-regressors = [r for r in _REGRESSORS if r is not regression.SGDRegressor]
+@pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
+def test_explain_weights_classifiers(newsgroups_train, clf):
+    clf = OneVsRestClassifier(clf)
+    assert_explained_weights_linear_classifier(newsgroups_train, clf,
+                                               add_bias=True)
 
-@pytest.mark.parametrize(['reg'],
+
+regressors = [r for r in _REGRESSORS if r is not regression.SGDRegressor]
+regressor_params = (
     [[reg()] for reg in regressors] +
     [[regression.SGDRegressor(eta0=1e-5, learning_rate='constant')]]
 )
-def test_explain_regressors(boston_train, reg):
+
+@pytest.mark.parametrize(['reg'], regressor_params)
+def test_explain_prediction_regressors(boston_train, reg):
     assert_linear_regression_explained(boston_train, reg, explain_prediction)
+
+
+@pytest.mark.parametrize(['reg'], regressor_params)
+def test_explain_weights_regressors(boston_train, reg):
+    assert_explained_weights_linear_regressor(boston_train, reg,
+                                              has_bias=False)

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -5,7 +5,7 @@ import re
 
 import numpy as np
 import scipy.sparse as sp
-from sklearn.datasets import make_regression
+from sklearn.datasets import make_regression, make_multilabel_classification
 from sklearn.feature_extraction.text import (
     CountVectorizer,
     TfidfVectorizer,
@@ -129,6 +129,21 @@ def assert_explained_weights_linear_regressor(boston_train, reg, has_bias=True):
 ])
 def test_explain_linear(newsgroups_train, clf):
     assert_explained_weights_linear_classifier(newsgroups_train, clf)
+
+
+@pytest.mark.parametrize(['clf'], [
+    [OneVsRestClassifier(SGDClassifier(random_state=42))],
+    [OneVsRestClassifier(LogisticRegression(random_state=42))],
+])
+def test_explain_linear_multilabel(clf):
+    X, Y = make_multilabel_classification(random_state=42)
+    clf.fit(X, Y)
+    res = explain_weights(clf)
+    expl_text, expl_html = format_as_all(res, clf)
+    for expl in [expl_text, expl_html]:
+        assert 'y=4' in expl
+        assert 'x0' in expl
+        assert 'BIAS' in expl
 
 
 @pytest.mark.parametrize(['clf'], [

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from functools import partial
 import re
 
+import numpy as np
+import scipy.sparse as sp
 from sklearn.datasets import make_regression
 from sklearn.feature_extraction.text import (
     CountVectorizer,
@@ -33,6 +35,7 @@ from sklearn.ensemble import (
 )
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.base import BaseEstimator
+from sklearn.multiclass import OneVsRestClassifier
 import pytest
 
 from eli5 import _graphviz
@@ -41,10 +44,13 @@ from eli5.sklearn import InvertableHashingVectorizer
 from .utils import format_as_all, get_all_features, get_names_coefs
 
 
-def check_newsgroups_explanation_linear(clf, vec, target_names):
-    get_res = lambda: explain_weights(
-        clf, vec=vec, target_names=target_names, top=20)
-    res = get_res()
+def check_newsgroups_explanation_linear(clf, vec, target_names, **kwargs):
+    def get_result():
+        _kwargs = dict(vec=vec, target_names=target_names, top=20)
+        _kwargs.update(kwargs)
+        return explain_weights(clf, **_kwargs)
+
+    res = get_result()
     expl_text, expl_html = format_as_all(res, clf)
 
     assert [cl.target for cl in res.targets] == target_names
@@ -65,7 +71,48 @@ def check_newsgroups_explanation_linear(clf, vec, target_names):
         for label in target_names:
             assert str(label) in expl
 
-    assert res == get_res()
+    assert res == get_result()
+
+
+def assert_explained_weights_linear_classifier(newsgroups_train, clf,
+                                               add_bias=False):
+    docs, y, target_names = newsgroups_train
+    vec = TfidfVectorizer()
+    X = vec.fit_transform(docs)
+    if add_bias:
+        X = sp.hstack([X, np.ones((X.shape[0], 1))])
+        feature_names = vec.get_feature_names() + ['BIAS']
+    else:
+        feature_names = None
+
+    clf.fit(X, y)
+    check_newsgroups_explanation_linear(clf, vec, target_names,
+                                        feature_names=feature_names,
+                                        top=(20, 20))
+
+
+def assert_explained_weights_linear_regressor(boston_train, reg, has_bias=True):
+    X, y, feature_names = boston_train
+    reg.fit(X, y)
+    res = explain_weights(reg)
+    expl_text, expl_html = format_as_all(res, reg)
+
+    for expl in [expl_text, expl_html]:
+        assert 'x12' in expl
+        assert 'x9' in expl
+
+    if has_bias:
+        assert '<BIAS>' in expl_text
+        assert '&lt;BIAS&gt;' in expl_html
+
+    pos, neg = top_pos_neg(res, 'y')
+    assert 'x12' in pos or 'x12' in neg
+    assert 'x9' in neg or 'x9' in pos
+
+    if has_bias:
+        assert '<BIAS>' in neg or '<BIAS>' in pos
+
+    assert res == explain_weights(reg)
 
 
 @pytest.mark.parametrize(['clf'], [
@@ -78,15 +125,10 @@ def check_newsgroups_explanation_linear(clf, vec, target_names):
     [PassiveAggressiveClassifier(random_state=42)],
     [Perceptron(random_state=42)],
     [LinearSVC(random_state=42)],
+    [OneVsRestClassifier(SGDClassifier(random_state=42))],
 ])
 def test_explain_linear(newsgroups_train, clf):
-    docs, y, target_names = newsgroups_train
-    vec = TfidfVectorizer()
-
-    X = vec.fit_transform(docs)
-    clf.fit(X, y)
-
-    check_newsgroups_explanation_linear(clf, vec, target_names)
+    assert_explained_weights_linear_classifier(newsgroups_train, clf)
 
 
 @pytest.mark.parametrize(['clf'], [
@@ -219,6 +261,9 @@ def test_explain_linear_feature_re(newsgroups_train, vec):
     [GradientBoostingClassifier(random_state=42)],
     [AdaBoostClassifier(learning_rate=0.1, n_estimators=200, random_state=42)],
     [DecisionTreeClassifier(max_depth=3, random_state=42)],
+
+    # FIXME:
+    # [OneVsRestClassifier(DecisionTreeClassifier(max_depth=3, random_state=42))],
 ])
 def test_explain_random_forest(newsgroups_train, clf):
     docs, y, target_names = newsgroups_train
@@ -234,7 +279,7 @@ def test_explain_random_forest(newsgroups_train, clf):
         assert 'feature importances' in expl
         assert 'god' in expl  # high-ranked feature
 
-    if isinstance(clf, DecisionTreeClassifier):
+    if isinstance(clf, (DecisionTreeClassifier, OneVsRestClassifier)):
         if _graphviz.is_supported():
             assert '<svg' in expl_html
         else:
@@ -284,7 +329,7 @@ def test_unsupported():
         assert 'BaseEstimator' in expl
 
 
-@pytest.mark.parametrize(['clf'], [
+@pytest.mark.parametrize(['reg'], [
     [ElasticNet(random_state=42)],
     [ElasticNetCV(random_state=42)],
     [Lars()],
@@ -295,24 +340,8 @@ def test_unsupported():
     [LinearRegression()],
     [LinearSVR(random_state=42)],
 ])
-def test_explain_linear_regression(boston_train, clf):
-    X, y, feature_names = boston_train
-    clf.fit(X, y)
-    res = explain_weights(clf)
-    expl_text, expl_html = format_as_all(res, clf)
-
-    for expl in [expl_text, expl_html]:
-        assert 'x12' in expl
-        assert 'x9' in expl
-    assert '<BIAS>' in expl_text
-    assert '&lt;BIAS&gt;' in expl_html
-
-    pos, neg = top_pos_neg(res, 'y')
-    assert 'x12' in pos or 'x12' in neg
-    assert 'x9' in neg or 'x9' in pos
-    assert '<BIAS>' in neg or '<BIAS>' in pos
-
-    assert res == explain_weights(clf)
+def test_explain_linear_regression(boston_train, reg):
+    assert_explained_weights_linear_regressor(boston_train, reg)
 
 
 def test_explain_linear_regression_feature_re(boston_train):
@@ -326,19 +355,19 @@ def test_explain_linear_regression_feature_re(boston_train):
         assert 'LSTAT' not in expl
 
 
-@pytest.mark.parametrize(['clf'], [
+@pytest.mark.parametrize(['reg'], [
     [ElasticNet(random_state=42)],
     [Lars()],
     [Lasso(random_state=42)],
     [Ridge(random_state=42)],
     [LinearRegression()],
 ])
-def test_explain_linear_regression_multitarget(clf):
+def test_explain_linear_regression_multitarget(reg):
     X, y = make_regression(n_samples=100, n_targets=3, n_features=10,
                            random_state=42)
-    clf.fit(X, y)
-    res = explain_weights(clf)
-    expl, _ = format_as_all(res, clf)
+    reg.fit(X, y)
+    res = explain_weights(reg)
+    expl, _ = format_as_all(res, reg)
 
     assert 'x9' in expl
     assert '<BIAS>' in expl
@@ -347,4 +376,4 @@ def test_explain_linear_regression_multitarget(clf):
     assert 'x9' in neg or 'x9' in pos
     assert '<BIAS>' in neg or '<BIAS>' in pos
 
-    assert res == explain_weights(clf)
+    assert res == explain_weights(reg)

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -9,6 +9,7 @@ from sklearn.linear_model import LogisticRegression, ElasticNet, SGDRegressor
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.multiclass import OneVsRestClassifier
 
 from eli5._feature_names import FeatureNames
 from eli5.sklearn.utils import (
@@ -123,6 +124,8 @@ def test_get_default_target_names():
     [RandomForestClassifier()],
     [GaussianNB()],
     [DecisionTreeClassifier()],
+    [OneVsRestClassifier(DecisionTreeClassifier())],
+    [OneVsRestClassifier(LogisticRegression())],
     [BernoulliNB()],
 ])
 def test_get_num_features(clf):

--- a/tests/test_sklearn_utils.py
+++ b/tests/test_sklearn_utils.py
@@ -7,6 +7,7 @@ from sklearn.datasets import make_classification, make_regression
 from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
 from sklearn.linear_model import LogisticRegression, ElasticNet, SGDRegressor
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import SGDClassifier
 from sklearn.naive_bayes import GaussianNB, BernoulliNB
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.multiclass import OneVsRestClassifier
@@ -22,16 +23,17 @@ from eli5.sklearn.utils import (
 )
 
 
-def test_has_intercept(newsgroups_train):
+@pytest.mark.parametrize(['clf', 'intercept'], [
+    [SGDClassifier(), True],
+    [SGDClassifier(fit_intercept=False), False],
+    [OneVsRestClassifier(SGDClassifier()), True],
+    [OneVsRestClassifier(SGDClassifier(fit_intercept=False)), False],
+])
+def test_has_intercept(newsgroups_train, clf, intercept):
     vec = TfidfVectorizer()
     X = vec.fit_transform(newsgroups_train[0])
-    clf = LogisticRegression()
     clf.fit(X, newsgroups_train[1])
-    assert has_intercept(clf)
-
-    clf2 = LogisticRegression(fit_intercept=False)
-    clf2.fit(X, newsgroups_train[1])
-    assert not has_intercept(clf2)
+    assert has_intercept(clf) == intercept
 
 
 def test_is_multiclass():


### PR DESCRIPTION
Todo:

* [x] tests for multilabel OneVsRestClassifier

Also, `explain_weights(OneVsRestClassifier(clf))` is not currently supported for decision trees and ensembles.