### PR TITLE
Show number of remaining feature importances

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import numpy as np
 
 from eli5.base import FeatureWeights, FeatureWeight
-from .utils import argsort_k_largest, argsort_k_smallest, mask
+from .utils import argsort_k_largest_positive, argsort_k_smallest, mask
 
 
 def _get_top_features(feature_names, coef, top):
@@ -51,9 +51,7 @@ def get_top_features(feature_names, coef, top):
 
 
 def _get_top_abs_features(feature_names, coef, k):
-    nnz = np.count_nonzero(coef)
-    k = nnz if k is None else min(nnz, k)
-    indices = argsort_k_largest(np.abs(coef), k)
+    indices = argsort_k_largest_positive(np.abs(coef), k)
     features = _features(indices, feature_names, coef)
     pos = [fw for fw in features if fw.weight > 0]
     neg = [fw for fw in features if fw.weight < 0]
@@ -61,9 +59,7 @@ def _get_top_abs_features(feature_names, coef, k):
 
 
 def _get_top_positive_features(feature_names, coef, k):
-    num_positive = (coef > 0).sum()
-    k = num_positive if k is None else min(num_positive, k)
-    indices = argsort_k_largest(coef, k)
+    indices = argsort_k_largest_positive(coef, k)
     return _features(indices, feature_names, coef)
 
 

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -21,7 +21,7 @@ class Explanation(object):
                  method=None,  # type: str
                  is_regression=False,  # type: bool
                  targets=None,  # type: List[TargetExplanation]
-                 feature_importances=None,  # type: List[FeatureWeight]
+                 feature_importances=None,  # type: FeatureImportances
                  decision_tree=None,  # type: TreeInfo
                  highlight_spaces=None,
                  transition_features=None,  # type: TransitionFeatureWeights
@@ -43,6 +43,15 @@ class Explanation(object):
         from eli5.formatters import fields
         from eli5.formatters.html import format_as_html
         return format_as_html(self, force_weights=False, show=fields.WEIGHTS)
+
+
+@attrs
+class FeatureImportances(object):
+    """ Feature importances with number of remaining non-zero features.
+    """
+    def __init__(self, importances, remaining):
+        self.importances = importances  # type: List[FeatureWeight]
+        self.remaining = remaining  # type: int
 
 
 @attrs

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -79,7 +79,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         horizontal_layout=horizontal_layout,
         any_weighted_spans=any(t.weighted_spans for t in targets),
         feat_imp_weight_range=max_or_0(
-            abs(fw.weight) for fw in (explanation.feature_importances or [])),
+            abs(fw.weight) for fw in explanation.feature_importances.importances)
+        if explanation.feature_importances else 0,
         target_weight_range=max_or_0(
             get_weight_range(t.feature_weights) for t in targets),
         other_weight_range=max_or_0(

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -53,7 +53,7 @@ def should_highlight_spaces(explanation):
     if explanation.feature_importances:
         hl_spaces = hl_spaces or any(
             _has_invisible_spaces(fw.feature)
-            for fw in explanation.feature_importances)
+            for fw in explanation.feature_importances.importances)
     if explanation.targets:
         hl_spaces = hl_spaces or any(
             _has_invisible_spaces(fw.feature)

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -34,7 +34,7 @@ from sklearn.tree import DecisionTreeClassifier
 from eli5.base import (
     Explanation, TargetExplanation, FeatureWeight, FeatureImportances)
 from eli5._feature_weights import get_top_features
-from eli5.utils import argsort_k_largest, get_target_display_names
+from eli5.utils import argsort_k_largest_positive, get_target_display_names
 from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing
 from eli5.sklearn.treeinspect import get_tree_info
 from eli5.sklearn.utils import (
@@ -259,7 +259,7 @@ def explain_rf_feature_importance(clf,
         coef = coef[flt_indices]
         coef_std = coef_std[flt_indices]
 
-    indices = argsort_k_largest(coef, top)
+    indices = argsort_k_largest_positive(coef, top)
     names, values, std = feature_names[indices], coef[indices], coef_std[indices]
     return Explanation(
         feature_importances=FeatureImportances(
@@ -305,7 +305,7 @@ def explain_decision_tree(clf,
     if feature_re is not None:
         feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
         coef = coef[flt_indices]
-    indices = argsort_k_largest(coef, top)
+    indices = argsort_k_largest_positive(coef, top)
     names, values = feature_names[indices], coef[indices]
     export_graphviz_kwargs.setdefault("proportion", True)
     tree_info = get_tree_info(

--- a/eli5/templates/explain.html
+++ b/eli5/templates/explain.html
@@ -29,12 +29,12 @@
             </tr>
             </thead>
             <tbody>
-            {% for fw in expl.feature_importances %}
+            {% for fw in expl.feature_importances.importances %}
                 <tr style="background-color: {{ fw.weight|weight_color(feat_imp_weight_range) }}; {{ tr_styles }}">
                     <td style="{{ td1_styles }}">
                         {{ "%0.4f"|format(fw.weight) }}
                         {% if not fw.std is none %}
-                             &plusmn; {{ "%0.4f"|format(2 * fw.std) }}
+                            &plusmn; {{ "%0.4f"|format(2 * fw.std) }}
                         {% endif %}
                     </td>
                     <td style="{{ td2_styles }}">
@@ -42,6 +42,15 @@
                     </td>
                 </tr>
             {% endfor %}
+            {% if expl.feature_importances.remaining %}
+                {% with fw = expl.feature_importances.importances|last %}
+                    <tr style="background-color: {{ fw.weight|weight_color(feat_imp_weight_range) }}; {{ tr_styles }}">
+                        <td colspan="2" style="{{ tdm_styles }}">
+                            <i>&hellip; {{ expl.feature_importances.remaining }} more &hellip;</i>
+                        </td>
+                    </tr>
+                {% endwith %}
+            {% endif %}
             </tbody>
         </table>
     {% endif %}

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -6,7 +6,7 @@ from scipy import sparse as sp
 def argsort_k_largest(x, k):
     """ Return no more than ``k`` indices of largest values. """
     if k == 0:
-        return np.array([])
+        return np.array([], dtype=np.intp)
     if k is None or k >= len(x):
         return np.argsort(x)[::-1]
     indices = np.argpartition(x, -k)[-k:]
@@ -14,10 +14,16 @@ def argsort_k_largest(x, k):
     return indices[np.argsort(-values)]
 
 
+def argsort_k_largest_positive(x, k):
+    num_positive = (x > 0).sum()
+    k = num_positive if k is None else min(num_positive, k)
+    return argsort_k_largest(x, k)
+
+
 def argsort_k_smallest(x, k):
     """ Return no more than ``k`` indices of smallest values. """
     if k == 0:
-        return np.array([])
+        return np.array([], dtype=np.intp)
     if k is None or k >= len(x):
         return np.argsort(x)
     indices = np.argpartition(x, k)[:k]

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -2,9 +2,10 @@
 from __future__ import absolute_import
 from singledispatch import singledispatch
 
+import numpy as np
 from xgboost import XGBClassifier, XGBRegressor
 
-from eli5.base import FeatureWeight, Explanation
+from eli5.base import FeatureWeight, FeatureImportances, Explanation
 from eli5.explain import explain_weights
 from eli5.sklearn.utils import get_feature_names
 from eli5.utils import argsort_k_largest
@@ -39,7 +40,10 @@ def explain_weights_xgboost(xgb,
     indices = argsort_k_largest(coef, top)
     names, values = feature_names[indices], coef[indices]
     return Explanation(
-        feature_importances=[FeatureWeight(*x) for x in zip(names, values)],
+        feature_importances=FeatureImportances(
+            [FeatureWeight(*x) for x in zip(names, values)],
+            remaining=np.count_nonzero(coef) - len(indices),
+        ),
         description=DESCRIPTION_XGBOOST,
         estimator=repr(xgb),
         method='feature importances',

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -8,7 +8,7 @@ from xgboost import XGBClassifier, XGBRegressor
 from eli5.base import FeatureWeight, FeatureImportances, Explanation
 from eli5.explain import explain_weights
 from eli5.sklearn.utils import get_feature_names
-from eli5.utils import argsort_k_largest
+from eli5.utils import argsort_k_largest_positive
 
 
 DESCRIPTION_XGBOOST = """
@@ -37,7 +37,7 @@ def explain_weights_xgboost(xgb,
         feature_names, flt_indices = feature_names.filtered_by_re(feature_re)
         coef = coef[flt_indices]
 
-    indices = argsort_k_largest(coef, top)
+    indices = argsort_k_largest_positive(coef, top)
     names, values = feature_names[indices], coef[indices]
     return Explanation(
         feature_importances=FeatureImportances(

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -293,6 +293,7 @@ def test_explain_random_forest(newsgroups_train, clf):
     for expl in [expl_text, expl_html]:
         assert 'feature importances' in expl
         assert 'god' in expl  # high-ranked feature
+        assert 'more features' in expl or 'more &hellip;' in expl
 
     if isinstance(clf, (DecisionTreeClassifier, OneVsRestClassifier)):
         if _graphviz.is_supported():
@@ -318,6 +319,7 @@ def test_explain_random_forest_and_tree_feature_re(newsgroups_train, clf):
     for expl in format_as_all(res, clf):
         assert 'under' in expl
         assert 'god' not in expl  # filtered out
+        assert 'more features' in expl or 'more &hellip;' in expl
 
 
 def test_explain_empty(newsgroups_train):

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -286,14 +286,16 @@ def test_explain_random_forest(newsgroups_train, clf):
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
 
-    get_res = lambda: explain_weights(clf, vec=vec, target_names=target_names,
-                                      top=30)
+    top = 30
+    get_res = lambda: explain_weights(
+        clf, vec=vec, target_names=target_names, top=top)
     res = get_res()
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:
         assert 'feature importances' in expl
         assert 'god' in expl  # high-ranked feature
-        assert 'more features' in expl or 'more &hellip;' in expl
+        if len(res.feature_importances.importances) > top:
+            assert 'more features' in expl or 'more &hellip;' in expl
 
     if isinstance(clf, (DecisionTreeClassifier, OneVsRestClassifier)):
         if _graphviz.is_supported():
@@ -313,13 +315,15 @@ def test_explain_random_forest_and_tree_feature_re(newsgroups_train, clf):
     vec = CountVectorizer()
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
+    top = 30
     res = explain_weights(
-        clf, vec=vec, target_names=target_names, feature_re='^un')
+        clf, vec=vec, target_names=target_names, feature_re='^a', top=top)
     res.decision_tree = None  # does not respect feature_re
     for expl in format_as_all(res, clf):
-        assert 'under' in expl
+        assert 'am' in expl
         assert 'god' not in expl  # filtered out
-        assert 'more features' in expl or 'more &hellip;' in expl
+        if len(res.feature_importances.importances) > top:
+            assert 'more features' in expl or 'more &hellip;' in expl
 
 
 def test_explain_empty(newsgroups_train):
@@ -394,3 +398,20 @@ def test_explain_linear_regression_multitarget(reg):
     assert '<BIAS>' in neg or '<BIAS>' in pos
 
     assert res == explain_weights(reg)
+
+
+@pytest.mark.parametrize(['clf'], [
+    [DecisionTreeClassifier()],
+    [ExtraTreesClassifier()],
+])
+def test_feature_importances_no_remaining(clf):
+    """ Check that number of remaining features is not shown if it is zero,
+    and that features with zero importance are not shown either.
+    """
+    n = 100
+    clf.fit(np.array([[i % 2 + 0.1 * np.random.random(), 0] for i in range(n)]),
+            np.array([i % 2 for i in range(n)]))
+    res = explain_weights(clf)
+    for expl in format_as_all(res, clf):
+        assert 'more features' not in expl and 'more &hellip;' not in expl
+        assert 'x1' not in expl  # it has zero importance

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,8 @@ import numpy as np
 from hypothesis import given, assume
 from hypothesis.strategies import integers
 
-from eli5.utils import argsort_k_largest, argsort_k_smallest
+from eli5.utils import (
+    argsort_k_largest, argsort_k_largest_positive, argsort_k_smallest)
 from .utils import rnd_len_arrays
 
 
@@ -43,3 +44,21 @@ def test_argsort_k_largest_zero(x):
 @given(rnd_len_arrays(np.float32, 0, 5))
 def test_argsort_k_largest_None(x):
     assert len(argsort_k_largest(x, None)) == len(x)
+
+
+def test_argsort_k_largest_empty():
+    x = np.array([0])
+    empty = np.array([])
+    assert _np_eq(x[argsort_k_largest(x, 0)], empty)
+    assert _np_eq(x[argsort_k_largest_positive(x, None)], empty)
+
+
+def test_argsort_k_largest_positive():
+    assert _np_eq(argsort_k_largest_positive(np.array([1.0, 0.0, 2.0]), None),
+                  np.array([2, 0]))
+    assert _np_eq(argsort_k_largest_positive(np.array([1.0, 0.0, 2.0, 4.0]), 2),
+                  np.array([3, 2]))
+
+
+def _np_eq(x, y):
+    return x.shape == y.shape and np.allclose(x, y)

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -6,7 +6,8 @@ from xgboost import XGBClassifier, XGBRegressor
 
 from .test_sklearn_explain_weights import (
     test_explain_random_forest as _check_rf,
-    test_explain_random_forest_and_tree_feature_re as _check_rf_feature_re
+    test_explain_random_forest_and_tree_feature_re as _check_rf_feature_re,
+    test_feature_importances_no_remaining as _check_rf_no_remaining,
 )
 
 # TODO: XGBRegressor
@@ -18,3 +19,7 @@ def test_explain_xgboost(newsgroups_train):
 
 def test_explain_xgboost_feature_re(newsgroups_train):
     _check_rf_feature_re(newsgroups_train, XGBClassifier())
+
+
+def test_feature_importances_no_remaining():
+    _check_rf_no_remaining(XGBClassifier())


### PR DESCRIPTION
Fixes #109 

Example output in html:
![2016-12-14 19 40 07](https://cloud.githubusercontent.com/assets/424613/21178938/2b912df4-c235-11e6-8146-ea4accf0f450.png)
and in the terminal:
![2016-12-14 19 41 19](https://cloud.githubusercontent.com/assets/424613/21178982/5086259c-c235-11e6-985a-395e6d078087.png)

I also added an extra space (for text formatter) between feature importance and feature name, like we already have for feature weights.