### PR TITLE
[wip] Add an option to expand missing features for explain_prediction

### DIFF
--- a/eli5/_feature_names.py
+++ b/eli5/_feature_names.py
@@ -29,6 +29,7 @@ class FeatureNames(Sized):
                     raise ValueError(
                         'unkn_template should be set for sparse features')
         self.feature_names = feature_names
+        self._own_feature_names = False  # can not modify them while it's False
         self.unkn_template = unkn_template
         self.n_features = n_features or len(feature_names)
         self.bias_name = bias_name
@@ -120,14 +121,18 @@ class FeatureNames(Sized):
         # self.add_feature to improve performance.
         idx = self.n_features
         if isinstance(self.feature_names, (list, np.ndarray)):
-            self.feature_names = list(self.feature_names)
+            if (not self._own_feature_names or
+                    isinstance(self.feature_names, np.ndarray)):
+                self.feature_names = list(self.feature_names)
             self.feature_names.append(feature)
         elif isinstance(self.feature_names, dict):
-            self.feature_names = dict(self.feature_names)
+            if not self._own_feature_names:
+                self.feature_names = dict(self.feature_names)
             self.feature_names[idx] = feature
         elif self.feature_names is None:
             self.feature_names = {idx: feature}
         self.n_features += 1
+        self._own_feature_names = True
         return idx
 
 

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import re
 from singledispatch import singledispatch
 import six
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 import scipy.sparse as sp
@@ -138,7 +138,8 @@ def explain_prediction_xgboost(
     names = xgb.classes_ if not is_regression else ['y']
     display_names = get_target_display_names(names, target_names, targets)
 
-    missing_map = {}  # map feature idx to missing feature idx
+    # map feature idx to missing feature idx
+    missing_map = {}  # type: Dict[Union[int, str], int]
     for _, (feature_weights, missing_feature_weights) in scores_weights:
         if expand_missing_features:
             for idx, value in six.iteritems(missing_feature_weights):
@@ -231,8 +232,9 @@ def _prediction_feature_weights(xgb, X, feature_names):
 
 
 def _target_feature_weights(leaf_ids, tree_dumps, X, missing):
-    feature_weights = defaultdict(float)
-    missing_feature_weights = defaultdict(float)
+    feature_weights = defaultdict(float)  # type: Dict[Union[int, str], float]
+    # Union below is a lie (only ints are keys), but mypy can't ignore it
+    missing_feature_weights = defaultdict(float)  # type: Dict[Union[int, str], float]
     # All trees in XGBoost give equal contribution to the prediction:
     # it is equal to sum of "leaf" values in leafs
     # before applying loss-specific function

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -94,7 +94,7 @@ def explain_prediction_xgboost(
         targets=None,
         feature_names=None,
         vectorized=False,
-        expand_missing_features=False,  # TODO - doc
+        expand_missing_features=False,
     ):
     """ Return an explanation of XGBoost prediction (via scikit-learn wrapper
     XGBClassifier or XGBRegressor) as feature weights.
@@ -108,6 +108,13 @@ def explain_prediction_xgboost(
     Contribution of one feature on the decision path is how much expected score
     changes from parent to child.
     Weights of all features sum to the output score of the estimator.
+
+    For correct handling of missing features, set missing argument of
+    XGBClassifier or XGBRegressor correctly (e.g. to 0 when working with
+    sklearn text vectorizers).
+    When expand_missing_features is set to True, each missing feature is
+    reported separately, as "feature (missing)"; when it is False,
+    all missing features weights are added together.
     """
     num_features = len(xgb.booster().feature_names)
     vec, feature_names = handle_vec(

--- a/tests/test_feature_names.py
+++ b/tests/test_feature_names.py
@@ -81,3 +81,4 @@ def test_add_feature(feature_names):
     assert feature_names[new_idx] == new_feature
     if storage is not None:
         assert storage is not feature_names.feature_names
+    # TODO - one more add

--- a/tests/test_feature_names.py
+++ b/tests/test_feature_names.py
@@ -73,12 +73,14 @@ def test_slice():
         [FeatureNames(n_features=5, unkn_template='%d')],
     ])
 def test_add_feature(feature_names):
-    len_before = len(feature_names)
-    storage = feature_names.feature_names
-    new_feature = 'new'
-    new_idx = feature_names.add_feature(new_feature)
-    assert len(feature_names) == len_before + 1
-    assert feature_names[new_idx] == new_feature
-    if storage is not None:
-        assert storage is not feature_names.feature_names
-    # TODO - one more add
+    for i in range(3):
+        len_before = len(feature_names)
+        storage = feature_names.feature_names
+        new_feature = 'new {}'.format(i)
+        new_idx = feature_names.add_feature(new_feature)
+        assert len(feature_names) == len_before + 1
+        assert feature_names[new_idx] == new_feature
+        if i > 0:
+            assert storage is feature_names.feature_names
+        elif storage is not None:
+            assert storage is not feature_names.feature_names

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -44,7 +44,13 @@ def test_explain_xgboost_regressor(boston_train):
         assert 'LSTAT' in expl
 
 
-def test_explain_prediction_clf_binary(newsgroups_train_binary_big):
+@pytest.mark.parametrize(['emf', 'top'], [
+    [False, None],
+    [False, 10],
+    [True, None],
+    [True, 10],
+])
+def test_explain_prediction_clf_binary(newsgroups_train_binary_big, emf, top):
     docs, ys, target_names = newsgroups_train_binary_big
     vec = CountVectorizer(stop_words='english')
     clf = XGBClassifier(n_estimators=100, max_depth=2, missing=0)
@@ -52,18 +58,25 @@ def test_explain_prediction_clf_binary(newsgroups_train_binary_big):
     clf.fit(xs, ys)
     res = explain_prediction(
         clf, 'computer graphics in space: a sign of atheism',
-        vec=vec, target_names=target_names)
+        vec=vec, target_names=target_names, expand_missing_features=emf, top=top)
     format_as_all(res, clf)
-    check_targets_scores(res)
+    if top is None:
+        check_targets_scores(res)
     weights = res.targets[0].feature_weights
     pos_features = get_all_features(weights.pos)
     neg_features = get_all_features(weights.neg)
     assert 'graphics' in pos_features
     assert 'computer' in pos_features
     assert 'atheism' in neg_features
+    if emf:
+        assert 'god (missing)' in pos_features
+        assert 'file (missing)' in neg_features
+    else:
+        assert not any('missing' in str(f) for f in pos_features)
 
 
-def test_explain_prediction_clf_multitarget(newsgroups_train):
+@pytest.mark.parametrize(['emf'], [[True], [False]])
+def test_explain_prediction_clf_multitarget(newsgroups_train, emf):
     docs, ys, target_names = newsgroups_train
     vec = CountVectorizer(stop_words='english')
     xs = vec.fit_transform(docs)
@@ -71,7 +84,7 @@ def test_explain_prediction_clf_multitarget(newsgroups_train):
     clf.fit(xs, ys)
     res = explain_prediction(
         clf, 'computer graphics in space: a new religion',
-        vec=vec, target_names=target_names)
+        vec=vec, target_names=target_names, expand_missing_features=emf)
     format_as_all(res, clf)
     check_targets_scores(res)
     graphics_weights = res.targets[1].feature_weights
@@ -80,7 +93,8 @@ def test_explain_prediction_clf_multitarget(newsgroups_train):
     assert 'religion' in get_all_features(religion_weights.pos)
 
 
-def test_explain_prediction_clf_xor():
+@pytest.mark.parametrize(['emf'], [[True], [False]])
+def test_explain_prediction_clf_xor(emf):
     true_xs = [[np.random.randint(2), np.random.randint(2)] for _ in range(100)]
     xs = np.array([[np.random.normal(x, 0.2), np.random.normal(y, 0.2)]
                    for x, y in true_xs])
@@ -88,10 +102,12 @@ def test_explain_prediction_clf_xor():
     clf = XGBClassifier(n_estimators=100, max_depth=2)
     clf.fit(xs, ys)
     for x in [[0, 1], [1, 0], [0, 0], [1, 1]]:
-        res = explain_prediction(clf, np.array(x))
+        res = explain_prediction(clf, np.array(x), expand_missing_features=emf)
         print(x)
-        print(format_as_text(res, show=fields.WEIGHTS))
+        expl = format_as_text(res, show=fields.WEIGHTS)
+        print(expl)
         check_targets_scores(res)
+        assert 'missing' not in expl
 
 
 def test_explain_prediction_clf_interval():


### PR DESCRIPTION
In some cases it can be interesting to check what features are missing during prediction, because missing feature weight can be higher than the sum of all active features. Here ``expand_missing_features`` option is added.