### PR TITLE
Show feature value for explain_prediction

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -7,7 +7,7 @@ from eli5.base import FeatureWeights, FeatureWeight
 from .utils import argsort_k_largest_positive, argsort_k_smallest, mask
 
 
-def _get_top_features(feature_names, coef, top):
+def _get_top_features(feature_names, coef, top, x):
     """
     Return a ``(pos, neg)`` tuple. ``pos`` and ``neg`` are lists of
     ``(name, value)`` tuples for features with positive and negative
@@ -24,18 +24,19 @@ def _get_top_features(feature_names, coef, top):
       the function returns no more than ``num_pos`` positive features and
       no more than ``num_neg`` negative features. ``None`` value means
       'no limit'.
+    * ``x`` is a vector of feature values, passed to FeatureWeight.value.
     """
     if isinstance(top, (list, tuple)):
         num_pos, num_neg = list(top)  # "list" is just for mypy
-        pos = _get_top_positive_features(feature_names, coef, num_pos)
-        neg = _get_top_negative_features(feature_names, coef, num_neg)
+        pos = _get_top_positive_features(feature_names, coef, num_pos, x)
+        neg = _get_top_negative_features(feature_names, coef, num_neg, x)
     else:
-        pos, neg = _get_top_abs_features(feature_names, coef, top)
+        pos, neg = _get_top_abs_features(feature_names, coef, top, x)
     return pos, neg
 
 
-def get_top_features(feature_names, coef, top):
-    pos, neg = _get_top_features(feature_names, coef, top)
+def get_top_features(feature_names, coef, top, x=None):
+    pos, neg = _get_top_features(feature_names, coef, top, x)
     pos_coef = coef > 0
     neg_coef = coef < 0
     # pos_sum = sum(w for name, w in pos or [['', 0]])
@@ -50,29 +51,33 @@ def get_top_features(feature_names, coef, top):
     )
 
 
-def _get_top_abs_features(feature_names, coef, k):
+def _get_top_abs_features(feature_names, coef, k, x):
     indices = argsort_k_largest_positive(np.abs(coef), k)
-    features = _features(indices, feature_names, coef)
+    features = _features(indices, feature_names, coef, x)
     pos = [fw for fw in features if fw.weight > 0]
     neg = [fw for fw in features if fw.weight < 0]
     return pos, neg
 
 
-def _get_top_positive_features(feature_names, coef, k):
+def _get_top_positive_features(feature_names, coef, k, x):
     indices = argsort_k_largest_positive(coef, k)
-    return _features(indices, feature_names, coef)
+    return _features(indices, feature_names, coef, x)
 
 
-def _get_top_negative_features(feature_names, coef, k):
+def _get_top_negative_features(feature_names, coef, k, x):
     num_negative = (coef < 0).sum()
     k = num_negative if k is None else min(num_negative, k)
     indices = argsort_k_smallest(coef, k)
-    return _features(indices, feature_names, coef)
+    return _features(indices, feature_names, coef, x)
 
 
-def _features(indices, feature_names, coef):
+def _features(indices, feature_names, coef, x):
     names = mask(feature_names, indices)
-    values = mask(coef, indices)
-    return [FeatureWeight(name, weight) for name, weight in zip(names, values)]
-
-
+    weights = mask(coef, indices)
+    if x is not None:
+        values = mask(x, indices)
+        return [FeatureWeight(name, weight, value=value)
+                for name, weight, value in zip(names, weights, values)]
+    else:
+        return [FeatureWeight(name, weight)
+                for name, weight in zip(names, weights)]

--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -7,7 +7,7 @@ from eli5.base import FeatureWeights, FeatureWeight
 from .utils import argsort_k_largest_positive, argsort_k_smallest, mask
 
 
-def _get_top_features(feature_names, coef, top, x):
+def _get_top_features(feature_names, coef, top, x, missing):
     """
     Return a ``(pos, neg)`` tuple. ``pos`` and ``neg`` are lists of
     ``(name, value)`` tuples for features with positive and negative
@@ -25,18 +25,22 @@ def _get_top_features(feature_names, coef, top, x):
       no more than ``num_neg`` negative features. ``None`` value means
       'no limit'.
     * ``x`` is a vector of feature values, passed to FeatureWeight.value.
+    * ``missing`` is a value that is considered "missing" in ``x``.
     """
     if isinstance(top, (list, tuple)):
         num_pos, num_neg = list(top)  # "list" is just for mypy
-        pos = _get_top_positive_features(feature_names, coef, num_pos, x)
-        neg = _get_top_negative_features(feature_names, coef, num_neg, x)
+        pos = _get_top_positive_features(
+            feature_names, coef, num_pos, x, missing)
+        neg = _get_top_negative_features(
+            feature_names, coef, num_neg, x, missing)
     else:
-        pos, neg = _get_top_abs_features(feature_names, coef, top, x)
+        pos, neg = _get_top_abs_features(
+            feature_names, coef, top, x, missing)
     return pos, neg
 
 
-def get_top_features(feature_names, coef, top, x=None):
-    pos, neg = _get_top_features(feature_names, coef, top, x)
+def get_top_features(feature_names, coef, top, x=None, missing=np.nan):
+    pos, neg = _get_top_features(feature_names, coef, top, x, missing)
     pos_coef = coef > 0
     neg_coef = coef < 0
     # pos_sum = sum(w for name, w in pos or [['', 0]])
@@ -51,31 +55,33 @@ def get_top_features(feature_names, coef, top, x=None):
     )
 
 
-def _get_top_abs_features(feature_names, coef, k, x):
+def _get_top_abs_features(feature_names, coef, k, x, missing):
     indices = argsort_k_largest_positive(np.abs(coef), k)
-    features = _features(indices, feature_names, coef, x)
+    features = _features(indices, feature_names, coef, x, missing)
     pos = [fw for fw in features if fw.weight > 0]
     neg = [fw for fw in features if fw.weight < 0]
     return pos, neg
 
 
-def _get_top_positive_features(feature_names, coef, k, x):
+def _get_top_positive_features(feature_names, coef, k, x, missing):
     indices = argsort_k_largest_positive(coef, k)
-    return _features(indices, feature_names, coef, x)
+    return _features(indices, feature_names, coef, x, missing)
 
 
-def _get_top_negative_features(feature_names, coef, k, x):
+def _get_top_negative_features(feature_names, coef, k, x, missing):
     num_negative = (coef < 0).sum()
     k = num_negative if k is None else min(num_negative, k)
     indices = argsort_k_smallest(coef, k)
-    return _features(indices, feature_names, coef, x)
+    return _features(indices, feature_names, coef, x, missing)
 
 
-def _features(indices, feature_names, coef, x):
+def _features(indices, feature_names, coef, x, missing):
     names = mask(feature_names, indices)
     weights = mask(coef, indices)
     if x is not None:
         values = mask(x, indices)
+        if not np.isnan(missing):
+            values[values == missing] = np.nan
         return [FeatureWeight(name, weight, value=value)
                 for name, weight, value in zip(names, weights, values)]
     else:

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 from .base_utils import attrs
 from .formatters.features import FormattedFeatureName
@@ -103,10 +103,12 @@ class FeatureWeight(object):
                  feature,  # type: Feature
                  weight,  # type: float
                  std=None,  # type: float
+                 value=None,  # type: Any
                  ):
         self.feature = feature
         self.weight = weight
         self.std = std
+        self.value = value
 
 
 @attrs

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -11,7 +11,7 @@ from eli5 import _graphviz
 from eli5.base import TargetExplanation
 from eli5.utils import max_or_0
 from .utils import (
-    format_signed, has_any_values_for_weights, replace_spaces,
+    format_signed, format_value, has_any_values_for_weights, replace_spaces,
     should_highlight_spaces)
 from . import fields
 from .features import FormattedFeatureName
@@ -28,7 +28,7 @@ template_env.filters.update(dict(
     remaining_weight_color=lambda ws, w_range, pos_neg:
         format_hsl(remaining_weight_color_hsl(ws, w_range, pos_neg)),
     format_feature=lambda f, w, hl: _format_feature(f, w, hl_spaces=hl),
-    format_value=lambda v: _format_value(v),
+    format_value=format_value,
     format_decision_tree=lambda tree: _format_decision_tree(tree),
 ))
 
@@ -56,7 +56,7 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     targets = explanation.targets or []
     if len(targets) == 1:
         horizontal_layout = False
-    has_values_for_weights = has_any_values_for_weights(explanation)
+    show_values_for_weights = has_any_values_for_weights(explanation)
 
     rendered_weighted_spans = render_targets_weighted_spans(
         targets, preserve_density)
@@ -93,8 +93,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
             for other in weighted_spans_others if other),
         targets_with_weighted_spans=list(
             zip(targets, rendered_weighted_spans, weighted_spans_others)),
-        has_values_for_weights=has_values_for_weights,
-        weights_table_span=3 if has_values_for_weights else 2,
+        show_values_for_weights=show_values_for_weights,
+        weights_table_span=3 if show_values_for_weights else 2,
     )
 
 
@@ -271,15 +271,6 @@ def _format_decision_tree(treedict):
         return _graphviz.dot2svg(treedict.graphviz)
     else:
         return tree2text(treedict)
-
-
-def _format_value(value):
-    if value is None:
-        return ''
-    elif np.isnan(value):
-        return 'Missing'
-    else:
-        return '{:+.3f}'.format(value)
 
 
 def html_escape(text):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -111,7 +111,8 @@ so if feature values have different scales, features with highest weights
 might not be the most important.\
 '''.replace('\n', ' ')
 CONTRIBUTION_HELP = '''\
-Feature contribution already accounts for the feature value, and the sum
+Feature contribution already accounts for the feature value
+(for linear models, contribution = weight * feature value), and the sum
 of feature contributions is equal to the score or, for some classifiers,
 to the probability. Feature values are shown if "show_feature_values" is True.\
 '''.replace('\n', ' ')

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -36,7 +36,7 @@ template_env.filters.update(dict(
 def format_as_html(explanation, include_styles=True, force_weights=True,
                    show=fields.ALL, preserve_density=None,
                    highlight_spaces=None, horizontal_layout=True,
-                   show_feature_values=True):
+                   show_feature_values=False):
     """ Format explanation as html.
     Most styles are inline, but some are included separately in <style> tag,
     you can omit them by passing ``include_styles=False`` and call
@@ -50,8 +50,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     False turns it off.
     If ``horizontal_layout`` is True (default), multiclass classifier
     weights are laid out horizontally.
-    If ``show_feature_values`` is True (default), feature values are shown
-    if present.
+    If ``show_feature_values`` is True, feature values are shown if present.
+    Default is False.
     """
     template = template_env.get_template('explain.html')
     if highlight_spaces is None:

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -278,7 +278,10 @@ def _format_decision_tree(treedict):
 def _format_value(value):
     if value is None:
         return ''
-    return '{:+.3f}'.format(value)
+    elif np.isnan(value):
+        return 'Missing'
+    else:
+        return '{:+.3f}'.format(value)
 
 
 def html_escape(text):

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -100,7 +100,21 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
         show_feature_values=show_feature_values,
         weights_table_span=3 if show_feature_values else 2,
         explaining_prediction=explaining_prediction,
+        weight_help=html_escape(WEIGHT_HELP),
+        contribution_help=html_escape(CONTRIBUTION_HELP),
     )
+
+
+WEIGHT_HELP = '''\
+Feature weights. Note that weights do not account for feature value scales,
+so if feature values have different scales, features with highest weights
+might not be the most important.\
+'''.replace('\n', ' ')
+CONTRIBUTION_HELP = '''\
+Feature contribution already accounts for the feature value, and the sum
+of feature contributions is equal to the score or, for some classifiers,
+to the probability. Feature values are shown if "show_feature_values" is True.\
+'''.replace('\n', ' ')
 
 
 def format_html_styles():

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -35,7 +35,8 @@ template_env.filters.update(dict(
 
 def format_as_html(explanation, include_styles=True, force_weights=True,
                    show=fields.ALL, preserve_density=None,
-                   highlight_spaces=None, horizontal_layout=True):
+                   highlight_spaces=None, horizontal_layout=True,
+                   show_feature_values=True):
     """ Format explanation as html.
     Most styles are inline, but some are included separately in <style> tag,
     you can omit them by passing ``include_styles=False`` and call
@@ -49,6 +50,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     False turns it off.
     If ``horizontal_layout`` is True (default), multiclass classifier
     weights are laid out horizontally.
+    If ``show_feature_values`` is True (default), feature values are shown
+    if present.
     """
     template = template_env.get_template('explain.html')
     if highlight_spaces is None:
@@ -56,7 +59,8 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     targets = explanation.targets or []
     if len(targets) == 1:
         horizontal_layout = False
-    show_values_for_weights = has_any_values_for_weights(explanation)
+    explaining_prediction = has_any_values_for_weights(explanation)
+    show_feature_values = show_feature_values and explaining_prediction
 
     rendered_weighted_spans = render_targets_weighted_spans(
         targets, preserve_density)
@@ -93,8 +97,9 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
             for other in weighted_spans_others if other),
         targets_with_weighted_spans=list(
             zip(targets, rendered_weighted_spans, weighted_spans_others)),
-        show_values_for_weights=show_values_for_weights,
-        weights_table_span=3 if show_values_for_weights else 2,
+        show_feature_values=show_feature_values,
+        weights_table_span=3 if show_feature_values else 2,
+        explaining_prediction=explaining_prediction,
     )
 
 

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -11,7 +11,8 @@ from eli5 import _graphviz
 from eli5.base import TargetExplanation
 from eli5.utils import max_or_0
 from .utils import (
-    format_signed, replace_spaces, should_highlight_spaces)
+    format_signed, has_any_values_for_weights, replace_spaces,
+    should_highlight_spaces)
 from . import fields
 from .features import FormattedFeatureName
 from .trees import tree2text
@@ -55,15 +56,12 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     targets = explanation.targets or []
     if len(targets) == 1:
         horizontal_layout = False
+    has_values_for_weights = has_any_values_for_weights(explanation)
 
     rendered_weighted_spans = render_targets_weighted_spans(
         targets, preserve_density)
     weighted_spans_others = [
         t.weighted_spans.other if t.weighted_spans else None for t in targets]
-
-    has_values_for_weights = any(
-        fw.value is not None for t in targets for fw in chain(
-            t.feature_weights.pos, t.feature_weights.neg))
 
     return template.render(
         include_styles=include_styles,

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -158,9 +158,7 @@ def _targets_lines(explanation, hl_spaces, show_feature_values,
             header=table_header,
             col_align=col_align,
         )
-        header_sep = table[1]
-        max_width = len(header_sep)
-        table = [header_sep] + table
+        max_width = len(table[1])
         pos_table = '\n'.join(table[:-len(w.neg)])
         neg_table = '\n'.join(table[-len(w.neg):])
 

--- a/eli5/formatters/text.py
+++ b/eli5/formatters/text.py
@@ -18,14 +18,14 @@ _SPACE = '_' if six.PY2 else '░'
 
 
 def format_as_text(expl, show=fields.ALL, highlight_spaces=None,
-                   show_feature_values=True):
+                   show_feature_values=False):
     """ Format explanation as text.
     If ``highlight_spaces`` is None (default), spaces will be highlighted in
     feature names only if there are any spaces at the start or at the end of the
     feature. Setting it to True forces space highlighting, and setting it to False
     turns it off.
-    If ``show_feature_values`` is True (default), feature values are shown
-    if present.
+    If ``show_feature_values`` is True, feature values are shown if present.
+    Default is False.
     """
     lines = []  # type: List[str]
 

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -3,7 +3,7 @@ import re
 import six
 from typing import Any, Union, List, Dict
 
-import numpy as np
+import numpy as np  # type: ignore
 
 from eli5.base import Explanation
 from .features import FormattedFeatureName

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -122,8 +122,8 @@ def tabulate(data,  # type: List[List[Any]]
     if header:
         data.insert(1, ['-' * width for width in col_width])
 
-    line_tpl = '  '.join(
-        '{:%s%s}' % ({'l': '', 'r': '>', 'c': '^'}[align], width)
+    line_tpl = u'  '.join(
+        u'{:%s%s}' % ({'l': '', 'r': '>', 'c': '^'}[align], width)
         for align, width in zip(col_align, col_width))
     return [line_tpl.format(*row) for row in data]
 

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -1,5 +1,7 @@
+from itertools import chain
 import re
 from typing import Union, List, Dict
+
 
 from eli5.base import Explanation
 from .features import FormattedFeatureName
@@ -72,3 +74,13 @@ def _has_invisible_spaces(name):
         return any(_has_invisible_spaces(n['name']) for n in name)
     else:
         return name.startswith(' ') or name.endswith(' ')
+
+
+def has_any_values_for_weights(explanation):
+    # type: (Explanation) -> bool
+    if explanation.targets:
+        return any(fw.value is not None
+                   for t in explanation.targets for fw in chain(
+            t.feature_weights.pos, t.feature_weights.neg))
+    else:
+        return False

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -9,7 +9,8 @@ from .formatters import format_as_html, fields
 
 FORMAT_KWARGS = {'include_styles', 'force_weights',
                  'show', 'preserve_density',
-                 'highlight_spaces', 'horizontal_layout'}
+                 'highlight_spaces', 'horizontal_layout',
+                 'show_feature_values'}
 
 
 def show_weights(estimator, **kwargs):

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -194,6 +194,10 @@ def show_prediction(estimator, doc, **kwargs):
 
         Default is None.
 
+    show_feature_values : bool
+        When True, feature values are shown along with feature contributions.
+        Default is True.
+
     **kwargs: dict
         Keyword arguments. All keyword arguments are passed to
         concrete explain_prediction... implementations.

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -197,7 +197,7 @@ def show_prediction(estimator, doc, **kwargs):
 
     show_feature_values : bool
         When True, feature values are shown along with feature contributions.
-        Default is True.
+        Default is False.
 
     **kwargs: dict
         Keyword arguments. All keyword arguments are passed to

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -37,6 +37,7 @@ from sklearn.tree import (   # type: ignore
 from eli5.base import Explanation, TargetExplanation
 from eli5.utils import get_target_display_names
 from eli5.sklearn.utils import (
+    add_intercept,
     get_coef,
     get_default_target_names,
     get_X,
@@ -105,7 +106,7 @@ def explain_prediction_linear_classifier(clf, doc,
     score, = clf.decision_function(X)
 
     if has_intercept(clf):
-        X = _add_intercept(X)
+        X = add_intercept(X)
     x, = X
 
     res = Explanation(
@@ -167,7 +168,7 @@ def explain_prediction_linear_regressor(reg, doc,
     score, = reg.predict(X)
 
     if has_intercept(reg):
-        X = _add_intercept(X)
+        X = add_intercept(X)
     x, = X
 
     res = Explanation(
@@ -269,7 +270,7 @@ def explain_prediction_tree_classifier(
     is_multiclass = clf.n_classes_ > 2
     feature_weights = _trees_feature_weights(
         clf, X, feature_names, clf.n_classes_)
-    x, = _add_intercept(X)
+    x, = add_intercept(X)
 
     def _weights(label_id):
         scores = feature_weights[:, label_id]
@@ -342,7 +343,7 @@ def explain_prediction_tree_regressor(
     num_targets = getattr(reg, 'n_outputs_', 1)
     is_multitarget = num_targets > 1
     feature_weights = _trees_feature_weights(reg, X, feature_names, num_targets)
-    x, = _add_intercept(X)
+    x, = add_intercept(X)
 
     def _weights(label_id):
         scores = feature_weights[:, label_id]
@@ -438,12 +439,3 @@ def _multiply(X, coef):
         return X.multiply(sp.csr_matrix(coef))
     else:
         return np.multiply(X, coef)
-
-
-def _add_intercept(X):
-    """ Add intercept column to X """
-    intercept = np.ones((X.shape[0], 1))
-    if sp.issparse(X):
-        return sp.hstack([X, intercept]).tocsr()
-    else:
-        return np.hstack([X, intercept])

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -117,7 +117,7 @@ def explain_prediction_linear_classifier(clf, doc,
     def _weights(label_id):
         coef = get_coef(clf, label_id)
         scores = _multiply(x, coef)
-        return get_top_features(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top, x)
 
     display_names = get_target_display_names(clf.classes_, target_names,
                                              targets)
@@ -180,7 +180,7 @@ def explain_prediction_linear_regressor(reg, doc,
     def _weights(label_id):
         coef = get_coef(reg, label_id)
         scores = _multiply(x, coef)
-        return get_top_features(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top, x)
 
     names = get_default_target_names(reg)
     display_names = get_target_display_names(names, target_names, targets)
@@ -266,13 +266,14 @@ def explain_prediction_tree_classifier(
     else:
         score = None
 
+    is_multiclass = clf.n_classes_ > 2
     feature_weights = _trees_feature_weights(
         clf, X, feature_names, clf.n_classes_)
-    is_multiclass = clf.n_classes_ > 2
+    x, = _add_intercept(X)
 
     def _weights(label_id):
         scores = feature_weights[:, label_id]
-        return get_top_features(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top, x)
 
     res = Explanation(
         estimator=repr(clf),
@@ -341,10 +342,11 @@ def explain_prediction_tree_regressor(
     num_targets = getattr(reg, 'n_outputs_', 1)
     is_multitarget = num_targets > 1
     feature_weights = _trees_feature_weights(reg, X, feature_names, num_targets)
+    x, = _add_intercept(X)
 
     def _weights(label_id):
         scores = feature_weights[:, label_id]
-        return get_top_features(feature_names, scores, top)
+        return get_top_features(feature_names, scores, top, x)
 
     res = Explanation(
         estimator=repr(reg),

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -200,3 +200,12 @@ def handle_vec(clf, doc, vec, vectorized, feature_names, num_features=None):
     feature_names = get_feature_names(
         clf, vec, feature_names=feature_names, num_features=num_features)
     return vec, feature_names
+
+
+def add_intercept(X):
+    """ Add intercept column to X """
+    intercept = np.ones((X.shape[0], 1))
+    if sp.issparse(X):
+        return sp.hstack([X, intercept]).tocsr()
+    else:
+        return np.hstack([X, intercept])

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -9,14 +9,14 @@
         <thead>
         <tr style="{{ tr_styles }}">
             <th style="{{ td1_styles }}">
-                {% if has_values_for_weights %}
+                {% if show_values_for_weights %}
                     Contribution
                 {% else %}
                     Weight
                 {% endif %}
             </th>
             <th style="{{ td2_styles }}">Feature</th>
-            {% if has_values_for_weights %}
+            {% if show_values_for_weights %}
                 <th style="{{ td3_styles }}">Value</th>
             {% endif %}
         </tr>

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -8,8 +8,17 @@
            style="{{ target_table_styles }}{% if in_horizontal_layout %} width: 100%;{% else %} margin-bottom: 2em;{% endif %}">
         <thead>
         <tr style="{{ tr_styles }}">
-            <th style="{{ td1_styles }}">Weight</th>
+            <th style="{{ td1_styles }}">
+                {% if has_values_for_weights %}
+                    Contribution
+                {% else %}
+                    Weight
+                {% endif %}
+            </th>
             <th style="{{ td2_styles }}">Feature</th>
+            {% if has_values_for_weights %}
+                <th style="{{ td3_styles }}">Value</th>
+            {% endif %}
         </tr>
         </thead>
         <tbody>
@@ -18,7 +27,7 @@
         {% endfor %}
         {% if wts.pos_remaining %}
             <tr style="background-color: {{ wts.pos|remaining_weight_color(w_range, 'pos') }}; {{ tr_styles }}">
-                <td colspan="2" style="{{ tdm_styles }}">
+                <td colspan="{{ weights_table_span }}" style="{{ tdm_styles }}">
                     <i>&hellip; {{ wts.pos_remaining }} more positive &hellip;</i>
                 </td>
             </tr>
@@ -26,7 +35,7 @@
 
         {% if wts.neg_remaining %}
             <tr style="background-color: {{ wts.neg|remaining_weight_color(w_range, 'neg') }}; {{ tr_styles }}">
-                <td colspan="2" style="{{ tdm_styles }}">
+                <td colspan="{{ weights_table_span }}" style="{{ tdm_styles }}">
                     <i>&hellip; {{ wts.neg_remaining }} more negative &hellip;</i>
                 </td>
             </tr>

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -8,13 +8,15 @@
            style="{{ target_table_styles }}{% if in_horizontal_layout %} width: 100%;{% else %} margin-bottom: 2em;{% endif %}">
         <thead>
         <tr style="{{ tr_styles }}">
-            <th style="{{ td1_styles }}">
-                {% if explaining_prediction %}
-                    Contribution
-                {% else %}
-                    Weight
-                {% endif %}
-            </th>
+            {% if explaining_prediction %}
+                <th style="{{ td1_styles }}" title="{{ contribution_help }}">
+                    Contribution<sup>?</sup>
+                </th>
+            {% else %}
+                <th style="{{ td1_styles }}" title="{{ weight_help }}">
+                    Weight<sup>?</sup>
+                </th>
+            {% endif %}
             <th style="{{ td2_styles }}">Feature</th>
             {% if show_feature_values %}
                 <th style="{{ td3_styles }}">Value</th>

--- a/eli5/templates/weights_table.html
+++ b/eli5/templates/weights_table.html
@@ -9,14 +9,14 @@
         <thead>
         <tr style="{{ tr_styles }}">
             <th style="{{ td1_styles }}">
-                {% if show_values_for_weights %}
+                {% if explaining_prediction %}
                     Contribution
                 {% else %}
                     Weight
                 {% endif %}
             </th>
             <th style="{{ td2_styles }}">Feature</th>
-            {% if show_values_for_weights %}
+            {% if show_feature_values %}
                 <th style="{{ td3_styles }}">Value</th>
             {% endif %}
         </tr>

--- a/eli5/templates/weights_table_row.html
+++ b/eli5/templates/weights_table_row.html
@@ -5,7 +5,7 @@
     <td style="{{ td2_styles }}">
         {{ fw.feature|format_feature(fw.weight, hl_spaces) }}
     </td>
-    {% if show_values_for_weights %}
+    {% if show_feature_values %}
         <td style="{{ td3_styles }}">
             {{ fw.value|format_value }}
         </td>

--- a/eli5/templates/weights_table_row.html
+++ b/eli5/templates/weights_table_row.html
@@ -5,7 +5,7 @@
     <td style="{{ td2_styles }}">
         {{ fw.feature|format_feature(fw.weight, hl_spaces) }}
     </td>
-    {% if has_values_for_weights %}
+    {% if show_values_for_weights %}
         <td style="{{ td3_styles }}">
             {{ fw.value|format_value }}
         </td>

--- a/eli5/templates/weights_table_row.html
+++ b/eli5/templates/weights_table_row.html
@@ -5,4 +5,9 @@
     <td style="{{ td2_styles }}">
         {{ fw.feature|format_feature(fw.weight, hl_spaces) }}
     </td>
+    {% if has_values_for_weights %}
+        <td style="{{ td3_styles }}">
+            {{ fw.value|format_value }}
+        </td>
+    {% endif %}
 </tr>

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -34,11 +34,16 @@ def argsort_k_smallest(x, k):
 def mask(x, indices):
     """
     The same as x[indices], but return an empty array if indices are empty,
-    instead of returning all x elements.
+    instead of returning all x elements,
+    and handles sparse "vectors", returning dense arrays for them.
     """
     if not indices.shape[0]:
         return np.array([])
-    return x[indices]
+    elif sp.issparse(x) and len(x.shape) == 2 and len(indices.shape) == 1:
+        assert x.shape[0] == 1
+        return x[0, indices].toarray()[0]
+    else:
+        return x[indices]
 
 
 def indices_to_bool_mask(indices, size):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -64,7 +64,7 @@ def test_highlight_spaces(boston_train, hl_spaces, add_invisible_spaces):
     # last is left unmodified to check that we are doing "any", not "all"
     modified_feature_names = \
         [('{} ' if add_invisible_spaces else 'A {}').format(name)
-        for name in feature_names[:-1]] + [feature_names[-1]]
+         for name in feature_names[:-1]] + [feature_names[-1]]
     reg.fit(X, y)
     res = explain_weights_sklearn(
         reg, feature_names=modified_feature_names, top=len(feature_names) + 1)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import re
 
 import pytest
+import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
@@ -93,3 +94,23 @@ def test_highlight_spaces(boston_train, hl_spaces, add_invisible_spaces):
                     else:
                         assert ('A' + _SPACE + f) in expl
 
+
+def test_show_feature_values():
+    clf = LinearRegression()
+    clf.fit(np.array([[1, 0.1], [0, 0]]), np.array([0, 1]))
+    res = explain_weights_sklearn(clf)
+    for expl in format_as_all(res, clf):
+        assert 'Value' not in expl
+        assert 'Weight' in expl
+        assert 'x0' in expl
+    res = explain_prediction_sklearn(clf, np.array([1.52, 0.5]))
+    for expl in format_as_all(res, clf):
+        assert 'Contribution' in expl
+        assert 'Value' in expl
+        assert 'x0' in expl
+        assert '1.52' in expl
+    for expl in format_as_all(res, clf, show_feature_values=False):
+        assert 'Contribution' in expl
+        assert 'Value' not in expl
+        assert 'x0' in expl
+        assert '1.52' not in expl

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -99,12 +99,12 @@ def test_show_feature_values():
     clf = LinearRegression()
     clf.fit(np.array([[1, 0.1], [0, 0]]), np.array([0, 1]))
     res = explain_weights_sklearn(clf)
-    for expl in format_as_all(res, clf):
+    for expl in format_as_all(res, clf, show_feature_values=True):
         assert 'Value' not in expl
         assert 'Weight' in expl
         assert 'x0' in expl
     res = explain_prediction_sklearn(clf, np.array([1.52, 0.5]))
-    for expl in format_as_all(res, clf):
+    for expl in format_as_all(res, clf, show_feature_values=True):
         assert 'Contribution' in expl
         assert 'Value' in expl
         assert 'x0' in expl

--- a/tests/test_formatters_as_dict.py
+++ b/tests/test_formatters_as_dict.py
@@ -31,7 +31,11 @@ def test_format_as_dict():
            'targets': [
                {'target': 'y',
                 'feature_weights': {
-                    'pos': [{'feature': 'a', 'weight': 13.0, 'std': None}],
+                    'pos': [{
+                        'feature': 'a',
+                        'weight': 13.0,
+                        'std': None,
+                        'value': None}],
                     'pos_remaining': 0,
                     'neg': [],
                     'neg_remaining': 0,

--- a/tests/test_formatters_utils.py
+++ b/tests/test_formatters_utils.py
@@ -1,0 +1,54 @@
+import pytest
+
+from eli5.formatters.utils import tabulate, format_value
+
+
+def test_tabulate():
+    assert tabulate([]) == []
+    assert tabulate([], header=['foo', 'bar']) == [
+        'foo  bar',
+        '---  ---',
+    ]
+    assert tabulate([[1, 'oneee'], [2.3, 'two']]) == [
+        '1    oneee',
+        '2.3  two  ',
+    ]
+    assert tabulate([[1, 'oneee'], [2.3, 'two']], header=['Digit', '']) == [
+        'Digit       ',
+        '-----  -----',
+        '1      oneee',
+        '2.3    two  ',
+    ]
+    assert tabulate([[1, 'oneee'], [2.3, 'two']], header=['Digit', 'Word'],
+                    col_align='lr') == [
+        'Digit   Word',
+        '-----  -----',
+        '1      oneee',
+        '2.3      two',
+    ]
+    assert tabulate([[1, 'oneee'], [2.3, 'two']], header=['Digit', 'Word'],
+                    col_align='r') == [
+        'Digit   Word',
+        '-----  -----',
+        '    1  oneee',
+        '  2.3    two',
+    ]
+    assert tabulate([[1, 'oneee'], [2.3, 'two']], header=['Digit', 'Word'],
+                    col_align=['c', 'r']) == [
+        'Digit   Word',
+        '-----  -----',
+        '  1    oneee',
+        ' 2.3     two',
+    ]
+    with pytest.raises(ValueError):
+        assert tabulate([[1, 'oneee'], [2.3]])
+    with pytest.raises(ValueError):
+        assert tabulate([[1], [2.3]], header=['Digit', 'Word'])
+    with pytest.raises(ValueError):
+        assert tabulate([[1], [2.3]], header=['Digit'], col_align='rr')
+
+
+def test_format_value():
+    assert format_value(None) == ''
+    assert format_value(float('nan')) == 'Missing'
+    assert format_value(12.23333334) == '+12.233'

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -71,7 +71,7 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
                                        atol=1e-8):
     X, y, feature_names = boston_train
     reg.fit(X, y)
-    res = explain_prediction(reg, X[0])
+    res = explain_prediction(reg, X[0], feature_names=feature_names)
     expl_text, expl_html = expls = format_as_all(res, reg)
 
     assert len(res.targets) == 1
@@ -79,7 +79,7 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
     assert target.target == 'y'
     pos, neg = (get_all_features(target.feature_weights.pos),
                 get_all_features(target.feature_weights.neg))
-    assert 'x11' in pos or 'x11' in neg
+    assert 'LSTAT' in pos or 'LSTAT' in neg
 
     if has_intercept(reg):
         assert '<BIAS>' in pos or '<BIAS>' in neg
@@ -91,7 +91,7 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
         assert 'BIAS' not in expl_html
 
     for expl in [expl_text, expl_html]:
-        assert 'x11' in expl
+        assert 'LSTAT' in expl
         assert '(score' in expl
     assert "'y'" in expl_text
     assert '<b>y</b>' in strip_blanks(expl_html)
@@ -99,7 +99,7 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
     for expl in expls:
         assert_feature_values_present(expl, feature_names, X[0])
 
-    assert res == explain_prediction(reg, X[0])
+    assert res == explain_prediction(reg, X[0], feature_names=feature_names)
     check_targets_scores(res, atol=atol)
 
 

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -194,6 +194,8 @@ def test_explain_tree_clf_multiclass(clf, iris_train):
 def test_explain_tree_clf_binary(clf, iris_train_binary):
     X, y, feature_names = iris_train_binary
     clf.fit(X, y)
+    res = explain_prediction(clf, X[0], feature_names=feature_names)
+    format_as_all(res, clf)
     all_expls = []
     for x in X[:5]:
         res = explain_prediction(clf, x, feature_names=feature_names)
@@ -232,6 +234,9 @@ def test_explain_tree_regressor_multitarget(reg):
 def test_explain_tree_regressor(reg, boston_train):
     X, y, feature_names = boston_train
     reg.fit(X, y)
+    res = explain_prediction(reg, X[0], feature_names=feature_names)
+    print(X[0])
+    format_as_all(res, reg)
     all_expls = []
     for i, x in enumerate(X[:5]):
         res = explain_prediction(reg, x, feature_names=feature_names)
@@ -255,4 +260,4 @@ def test_explain_tree_classifier_text(clf, newsgroups_train_big):
     clf.fit(X, y)
     res = explain_prediction(clf, docs[0], vec=vec, target_names=target_names)
     check_targets_scores(res)
-    print(format_as_text(res, show=fields.WEIGHTS))
+    format_as_all(res, clf)

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from functools import partial
 from pprint import pprint
 
 import pytest
@@ -37,6 +38,9 @@ from eli5.formatters import format_as_text, fields
 from eli5.sklearn.utils import has_intercept
 from .utils import (
     format_as_all, strip_blanks, get_all_features, check_targets_scores)
+
+
+format_as_all = partial(format_as_all, show_feature_values=True)
 
 
 def assert_multiclass_linear_classifier_explained(newsgroups_train, clf,

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -104,8 +104,10 @@ def test_explain_prediction_clf_interval():
     ys = np.array([x == 1 for x, _ in true_xs])
     clf = XGBClassifier(n_estimators=100, max_depth=2)
     clf.fit(xs, ys)
-    res = explain_prediction(clf, np.array([1, 1]))
-    format_as_all(res, clf)
+    res = explain_prediction(clf, np.array([1.23, 1.45]))
+    for expl in format_as_all(res, clf):
+        assert 'x0' in expl
+        assert '1.23' in expl
     for x in [[0, 1], [1, 1], [2, 1], [0.8, 5], [1.2, 5]]:
         res = explain_prediction(clf, np.array(x))
         print(x)

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -88,6 +88,8 @@ def test_explain_prediction_clf_xor():
     ys = np.array([x == y for x, y in true_xs])
     clf = XGBClassifier(n_estimators=100, max_depth=2)
     clf.fit(xs, ys)
+    res = explain_prediction(clf, np.array([1, 1]))
+    format_as_all(res, clf)
     for x in [[0, 1], [1, 0], [0, 0], [1, 1]]:
         res = explain_prediction(clf, np.array(x))
         print(x)
@@ -102,6 +104,8 @@ def test_explain_prediction_clf_interval():
     ys = np.array([x == 1 for x, _ in true_xs])
     clf = XGBClassifier(n_estimators=100, max_depth=2)
     clf.fit(xs, ys)
+    res = explain_prediction(clf, np.array([1, 1]))
+    format_as_all(res, clf)
     for x in [[0, 1], [1, 1], [2, 1], [0.8, 5], [1.2, 5]]:
         res = explain_prediction(clf, np.array(x))
         print(x)
@@ -121,6 +125,7 @@ def test_explain_prediction_reg(boston_train):
     check_targets_scores(res)
     for expl in format_as_all(res, reg):
         assert 'LSTAT' in expl
+    format_as_all(res, reg)
 
 
 def test_explain_prediction_feature_union_dense():
@@ -142,7 +147,7 @@ def test_explain_prediction_feature_union_dense():
     res = explain_prediction(reg, xs[0], vec=vec, feature_names=['_x_', '_y_'])
     check_targets_scores(res)
     for expl in format_as_all(res, reg):
-        assert 'Missing features' in expl
+        assert 'Missing' in expl
         assert '_y_' in expl
         assert '_x_' not in expl
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -149,7 +149,7 @@ def test_explain_prediction_feature_union_dense():
     for expl in format_as_all(res, reg):
         assert 'Missing' in expl
         assert '_y_' in expl
-        assert '_x_' not in expl
+        assert '_x_' in expl
 
 
 def test_explain_prediction_feature_union_sparse(newsgroups_train_binary):

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -105,7 +105,7 @@ def test_explain_prediction_clf_interval():
     clf = XGBClassifier(n_estimators=100, max_depth=2)
     clf.fit(xs, ys)
     res = explain_prediction(clf, np.array([1.23, 1.45]))
-    for expl in format_as_all(res, clf):
+    for expl in format_as_all(res, clf, show_feature_values=True):
         assert 'x0' in expl
         assert '1.23' in expl
     for x in [[0, 1], [1, 1], [2, 1], [0.8, 5], [1.2, 5]]:
@@ -148,7 +148,7 @@ def test_explain_prediction_feature_union_dense():
     reg.fit(vec.transform(xs), ys)
     res = explain_prediction(reg, xs[0], vec=vec, feature_names=['_x_', '_y_'])
     check_targets_scores(res)
-    for expl in format_as_all(res, reg):
+    for expl in format_as_all(res, reg, show_feature_values=True):
         assert 'Missing' in expl
         assert '_y_' in expl
         assert '_x_' in expl


### PR DESCRIPTION
Fixes #126.
It is shown by default (**edit: it's not shown by default, as before**), and it's possible to pass ``show_feature_values=False`` to ``format_as_text`` and ``format_as_html``. Also the first column of weights table is called ``Contribution`` instead of ``Weight`` for ``explain_prediction``.
I considered using some library for formatting weights table, but could not find any that will allow customizing column alignment (we can have a mix of number and strings in the values column that needs to be right-aligned) and also have nice look, so I added a little function instead.