### PR TITLE
Handle missing values for xgboost

### DIFF
--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -7,7 +7,7 @@ from eli5.base import FeatureWeights, FeatureWeight
 from .utils import argsort_k_largest_positive, argsort_k_smallest, mask
 
 
-def _get_top_features(feature_names, coef, top, x, missing):
+def _get_top_features(feature_names, coef, top, x):
     """
     Return a ``(pos, neg)`` tuple. ``pos`` and ``neg`` are lists of
     ``(name, value)`` tuples for features with positive and negative
@@ -25,22 +25,20 @@ def _get_top_features(feature_names, coef, top, x, missing):
       no more than ``num_neg`` negative features. ``None`` value means
       'no limit'.
     * ``x`` is a vector of feature values, passed to FeatureWeight.value.
-    * ``missing`` is a value that is considered "missing" in ``x``.
     """
     if isinstance(top, (list, tuple)):
         num_pos, num_neg = list(top)  # "list" is just for mypy
         pos = _get_top_positive_features(
-            feature_names, coef, num_pos, x, missing)
+            feature_names, coef, num_pos, x)
         neg = _get_top_negative_features(
-            feature_names, coef, num_neg, x, missing)
+            feature_names, coef, num_neg, x)
     else:
-        pos, neg = _get_top_abs_features(
-            feature_names, coef, top, x, missing)
+        pos, neg = _get_top_abs_features(feature_names, coef, top, x)
     return pos, neg
 
 
-def get_top_features(feature_names, coef, top, x=None, missing=np.nan):
-    pos, neg = _get_top_features(feature_names, coef, top, x, missing)
+def get_top_features(feature_names, coef, top, x=None):
+    pos, neg = _get_top_features(feature_names, coef, top, x)
     pos_coef = coef > 0
     neg_coef = coef < 0
     # pos_sum = sum(w for name, w in pos or [['', 0]])
@@ -55,33 +53,31 @@ def get_top_features(feature_names, coef, top, x=None, missing=np.nan):
     )
 
 
-def _get_top_abs_features(feature_names, coef, k, x, missing):
+def _get_top_abs_features(feature_names, coef, k, x):
     indices = argsort_k_largest_positive(np.abs(coef), k)
-    features = _features(indices, feature_names, coef, x, missing)
+    features = _features(indices, feature_names, coef, x)
     pos = [fw for fw in features if fw.weight > 0]
     neg = [fw for fw in features if fw.weight < 0]
     return pos, neg
 
 
-def _get_top_positive_features(feature_names, coef, k, x, missing):
+def _get_top_positive_features(feature_names, coef, k, x):
     indices = argsort_k_largest_positive(coef, k)
-    return _features(indices, feature_names, coef, x, missing)
+    return _features(indices, feature_names, coef, x)
 
 
-def _get_top_negative_features(feature_names, coef, k, x, missing):
+def _get_top_negative_features(feature_names, coef, k, x):
     num_negative = (coef < 0).sum()
     k = num_negative if k is None else min(num_negative, k)
     indices = argsort_k_smallest(coef, k)
-    return _features(indices, feature_names, coef, x, missing)
+    return _features(indices, feature_names, coef, x)
 
 
-def _features(indices, feature_names, coef, x, missing):
+def _features(indices, feature_names, coef, x):
     names = mask(feature_names, indices)
     weights = mask(coef, indices)
     if x is not None:
         values = mask(x, indices)
-        if not np.isnan(missing):
-            values[values == missing] = np.nan
         return [FeatureWeight(name, weight, value=value)
                 for name, weight, value in zip(names, weights, values)]
     else:

--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -135,6 +135,7 @@ def explain_prediction(estimator, doc, **kwargs):
     feature_filter : Callable[[str, float], bool], optional
         Only feature names for which ``feature_filter`` function returns True
         are returned. It must accept feature name and it's value.
+        Missing features always have a NaN value.
 
     **kwargs: dict
         Keyword arguments. All keyword arguments are passed to

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -35,17 +35,22 @@ def mask(x, indices):
     """
     The same as x[indices], but return an empty array if indices are empty,
     instead of returning all x elements,
-    and handles sparse "vectors", returning dense arrays for them.
+    and handles sparse "vectors".
     """
     indices_shape = (
         [len(indices)] if isinstance(indices, list) else indices.shape)
     if not indices_shape[0]:
         return np.array([])
-    elif sp.issparse(x) and len(x.shape) == 2 and len(indices_shape) == 1:
-        assert x.shape[0] == 1
+    elif is_sparse_vector(x) and len(indices_shape) == 1:
         return x[0, indices].toarray()[0]
     else:
         return x[indices]
+
+
+def is_sparse_vector(x):
+    """ x is a 2D sparse matrix with it's first shape equal to 1.
+    """
+    return sp.issparse(x) and len(x.shape) == 2 and x.shape[0] == 1
 
 
 def indices_to_bool_mask(indices, size):

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -265,6 +265,8 @@ def _indexed_leafs(parent):
     """ Return a leaf nodeid -> node dictionary with
     "parent" and "leaf" (average child "leaf" value) added to all nodes.
     """
+    if not parent.get('children'):
+        return {parent['nodeid']: parent}
     indexed = {}
     for child in parent['children']:
         child['parent'] = parent

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -21,7 +21,7 @@ from eli5.sklearn.text import add_weighted_spans
 from eli5.sklearn.utils import (
     add_intercept, get_feature_names, get_X, handle_vec, predict_proba)
 from eli5.utils import (
-    argsort_k_largest_positive, get_target_display_names, mask)
+    argsort_k_largest_positive, get_target_display_names, mask, is_sparse_vector)
 from eli5._decision_path import DECISION_PATHS_CAVEATS
 from eli5._feature_weights import get_top_features
 
@@ -150,10 +150,12 @@ def explain_prediction_xgboost(
         # Work around XGBoost issue:
         # https://github.com/dmlc/xgboost/issues/1238#issuecomment-243872543
         X = X.tocsc()
-    x, = add_intercept(X)
 
     proba = predict_proba(xgb, X)
     scores_weights = _prediction_feature_weights(xgb, X, feature_names)
+
+    x, = add_intercept(X)
+    x = _missing_values_set_to_nan(x, xgb.missing, sparse_missing=True)
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
 
@@ -181,7 +183,7 @@ def explain_prediction_xgboost(
             _x = mask(_x, flt_indices)
             _feature_weights = mask(_feature_weights, flt_indices)
         return _score, get_top_features(
-            feature_names, _feature_weights, top, _x, xgb.missing)
+            feature_names, _feature_weights, top, _x)
 
     if is_multiclass:
         for label_id, label in display_names:
@@ -356,3 +358,29 @@ def _parse_dump_line(line):
             'cover': float(cover),
         }
     raise ValueError('Line in unexpected format: {}'.format(line))
+
+
+def _missing_values_set_to_nan(values, missing_value, sparse_missing):
+    """ Return a copy of values where missing values (equal to missing_value)
+    are replaced to nan according. If sparse_missing is True,
+    entries missing in a sparse matrix will also be set to nan.
+    Sparse matrices will be converted to dense format.
+    """
+    if sp.issparse(values):
+        assert values.shape[0] == 1
+    if sparse_missing and sp.issparse(values) and missing_value != 0:
+        # Nothing special needs to be done for missing.value == 0 because
+        # missing values are assumed to be zero in sparse matrices.
+        values_coo = values.tocoo()
+        values = values.toarray()[0]
+        missing_mask = values == 0
+        # fix for possible zero values
+        missing_mask[values_coo.col] = False
+        values[missing_mask] = np.nan
+    elif is_sparse_vector(values):
+        values = values.toarray()[0]
+    else:
+        values = values.copy()
+    if not np.isnan(missing_value):
+        values[values == missing_value] = np.nan
+    return values


### PR DESCRIPTION
Fixes #137.

XGBoost is able to distinguish missing and zero values in sparse matrices, so we set missing values to nan. The matrix is converted to dense format because the sparse matrix will be full anyway.

It needs to be done before feature filtering, else we won't be able to filter out missing features with ``feature_filter=lambda _, v: not np.nan(v)``. So I removed all handling of "missing" from eli5._feature_weights, as before xgboost.