### PR TITLE
Fix char_wb spans at the start of the document

### DIFF
--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -23,6 +23,8 @@ def get_char_weights(doc_weighted_spans, preserve_density=None):
     feature_counts = Counter(f for f, _, _ in doc_weighted_spans.spans)
     for feature, spans, weight in doc_weighted_spans.spans:
         for start, end in spans:
+            # start can be -1 for char_wb at the start of the document.
+            start = max(0, start)
             if preserve_density:
                 weight /= (end - start)
             weight /= feature_counts[feature]

--- a/tests/test_formatters_text_helpers.py
+++ b/tests/test_formatters_text_helpers.py
@@ -42,7 +42,8 @@ def test_prepare_weighted_spans():
                     DocWeightedSpans(
                         document='xz',
                         spans=[
-                            ('xz', [(0, 2)], 1.5),
+                            # char_wb at the start of the document
+                            (' xz', [(-1, 2)], 1.5),
                         ],
                     )],
             )),


### PR DESCRIPTION
Fixes #143 

The span start can be -1, because for document "ab"the first 3-gram will be " ab" that starts before the start of the document. Another option would be to fix it in _span_analyzers._char_wb_ngrams. But the ngram is really " ab" and it really starts before the start of the document, so I decided to fix it here, although I'm not 100% sure.