### PR TITLE
Add sklearn to install_requires, update install docs

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -5,10 +5,8 @@ Installation
 ------------
 
 ELI5 works in Python 2.7 and Python 3.4+. Currently it requires
-scikit-learn 0.18+, so make sure scikit-learn is installed first,
-then install eli5 using pip::
+scikit-learn 0.18+. You can install ELI5 using pip::
 
-    pip install 'scikit-learn > 0.18'
     pip install eli5
 
 Features

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'scipy',
         'singledispatch >= 3.4.0.3',
         'six',
+        'scikit-learn >= 0.18',
         'typing',
         'graphviz',
         'tabulate>=0.7.7',


### PR DESCRIPTION
Fixes #147

I removed a separate sklearn install step from the docs, but still left the mention that sklearn 0.18+ is required, since someone might be unwilling to update to 0.18 from 0.17 yet - not 100% sure it's worth having it in the README.