### PR TITLE
Handle improperly installed xgboost.

### DIFF
--- a/eli5/__init__.py
+++ b/eli5/__init__.py
@@ -38,3 +38,9 @@ try:
 except ImportError:
     # xgboost is not available
     pass
+except Exception as e:
+    if e.__class__.__name__ == 'XGBoostLibraryNotFound':
+        # improperly installed xgboost
+        pass
+    else:
+        raise


### PR DESCRIPTION
 Fixes #162. I've checked it the same way as @lopuhin suggested - renamed libxgboost.so file.