### PR TITLE
mypy update

### DIFF
--- a/eli5/base.py
+++ b/eli5/base.py
@@ -26,6 +26,7 @@ class Explanation(object):
                  highlight_spaces=None,
                  transition_features=None,  # type: TransitionFeatureWeights
                  ):
+        # type: (...) -> None
         self.estimator = estimator
         self.description = description
         self.error = error
@@ -50,6 +51,7 @@ class FeatureImportances(object):
     """ Feature importances with number of remaining non-zero features.
     """
     def __init__(self, importances, remaining):
+        # type: (...) -> None
         self.importances = importances  # type: List[FeatureWeight]
         self.remaining = remaining  # type: int
 
@@ -67,6 +69,7 @@ class TargetExplanation(object):
                  score=None,  # type: float
                  weighted_spans=None,  # type: WeightedSpans
                  ):
+        # type: (...) -> None
         self.target = target
         self.feature_weights = feature_weights
         self.proba = proba
@@ -91,6 +94,7 @@ class FeatureWeights(object):
                  pos_remaining=0,  # type: int
                  neg_remaining=0,  # type: int
                  ):
+        # type: (...) -> None
         self.pos = pos
         self.neg = neg
         self.pos_remaining = pos_remaining
@@ -105,6 +109,7 @@ class FeatureWeight(object):
                  std=None,  # type: float
                  value=None,  # type: Any
                  ):
+        # type: (...) -> None
         self.feature = feature
         self.weight = weight
         self.std = std
@@ -120,6 +125,7 @@ class WeightedSpans(object):
                  docs_weighted_spans,  # type: List[DocWeightedSpans]
                  other=None,  # type: FeatureWeights
                  ):
+        # type: (...) -> None
         self.docs_weighted_spans = docs_weighted_spans
         self.other = other
 
@@ -146,6 +152,7 @@ class DocWeightedSpans(object):
                  preserve_density=None,  # type: bool
                  vec_name=None,  # type: str
                  ):
+        # type: (...) -> None
         self.document = document
         self.spans = spans
         self.preserve_density = preserve_density
@@ -159,6 +166,7 @@ class TransitionFeatureWeights(object):
                  class_names,  # type: List[str],
                  coef,
                  ):
+        # type: (...) -> None
         self.class_names = class_names
         self.coef = coef
 
@@ -175,6 +183,7 @@ class TreeInfo(object):
                  graphviz,  # type: str
                  is_classification, # type: bool
                  ):
+        # type: (...) -> None
         self.criterion = criterion
         self.tree = tree
         self.graphviz = graphviz
@@ -200,6 +209,7 @@ class NodeInfo(object):
                  left=None,          # type: NodeInfo
                  right=None,         # type: NodeInfo
                  ):
+        # type: (...) -> None
         self.id = id
         self.is_leaf = is_leaf
         self.value = value

--- a/eli5/base.py
+++ b/eli5/base.py
@@ -163,7 +163,7 @@ class DocWeightedSpans(object):
 class TransitionFeatureWeights(object):
     """ Weights matrix for transition features. """
     def __init__(self,
-                 class_names,  # type: List[str],
+                 class_names,  # type: List[str]
                  coef,
                  ):
         # type: (...) -> None

--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -22,7 +22,7 @@ from .text_helpers import prepare_weighted_spans, PreparedWeightedSpans
 template_env = Environment(
     loader=PackageLoader('eli5', 'templates'),
     extensions=['jinja2.ext.with_'])
-template_env.globals.update(zip=zip, numpy=np)
+template_env.globals.update(dict(zip=zip, numpy=np))
 template_env.filters.update(dict(
     weight_color=lambda w, w_range: format_hsl(weight_color_hsl(w, w_range)),
     remaining_weight_color=lambda ws, w_range, pos_neg:

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -20,7 +20,7 @@ def get_char_weights(doc_weighted_spans, preserve_density=None):
     if preserve_density is None:
         preserve_density = doc_weighted_spans.preserve_density
     char_weights = np.zeros(len(doc_weighted_spans.document))
-    feature_counts = Counter(f for f, _, _ in doc_weighted_spans.spans)
+    feature_counts = Counter(f for f, _, __ in doc_weighted_spans.spans)
     for feature, spans, weight in doc_weighted_spans.spans:
         for start, end in spans:
             # start can be -1 for char_wb at the start of the document.

--- a/eli5/formatters/text_helpers.py
+++ b/eli5/formatters/text_helpers.py
@@ -39,6 +39,7 @@ class PreparedWeightedSpans(object):
                  char_weights,  # type: np.ndarray
                  weight_range,  # type: float
                  ):
+        # type: (...) -> None
         self.doc_weighted_spans = doc_weighted_spans
         self.char_weights = char_weights
         self.weight_range = weight_range

--- a/eli5/formatters/utils.py
+++ b/eli5/formatters/utils.py
@@ -69,7 +69,7 @@ def should_highlight_spaces(explanation):
 
 
 def _has_invisible_spaces(name):
-    # type: (Union[str, List[Dict]]) -> bool
+    # type: (Union[str, List[Dict], FormattedFeatureName]) -> bool
     if isinstance(name, FormattedFeatureName):
         return False
     elif isinstance(name, list):

--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -16,7 +16,6 @@ from eli5.sklearn import (
 from eli5.explain import explain_prediction, explain_weights
 
 
-@explain_weights.register(BaseEstimator)
 @singledispatch
 def explain_weights_lightning(estimator, vec=None, top=20, target_names=None,
                               targets=None, feature_names=None,
@@ -28,7 +27,6 @@ def explain_weights_lightning(estimator, vec=None, top=20, target_names=None,
     )
 
 
-@explain_prediction.register(BaseEstimator)
 @singledispatch
 def explain_prediction_lightning(estimator, doc, vec=None, top=None,
                                  target_names=None, targets=None,
@@ -84,10 +82,14 @@ _REGRESSORS = [
 ]
 
 for clf in _CLASSIFIERS:
+    explain_weights.register(clf, explain_linear_classifier_weights)
     explain_weights_lightning.register(clf, explain_linear_classifier_weights)
+    explain_prediction.register(clf, explain_prediction_linear_classifier)
     explain_prediction_lightning.register(clf, explain_prediction_linear_classifier)
 
 
 for reg in _REGRESSORS:
+    explain_weights.register(reg, explain_linear_regressor_weights)
     explain_weights_lightning.register(reg, explain_linear_regressor_weights)
+    explain_prediction.register(reg, explain_prediction_linear_regressor)
     explain_prediction_lightning.register(reg, explain_prediction_linear_regressor)

--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -21,9 +21,17 @@ def explain_weights_lightning(estimator, vec=None, top=20, target_names=None,
                               targets=None, feature_names=None,
                               coef_scale=None):
     """ Return an explanation of a lightning estimator weights """
+    return explain_weights_lightning_not_supported(estimator)
+
+
+@explain_weights.register(BaseEstimator)
+def explain_weights_lightning_not_supported(
+        estimator, vec=None, top=20, target_names=None,
+        targets=None, feature_names=None,
+        coef_scale=None):
     return Explanation(
         estimator=repr(estimator),
-        description="Error: estimator %r is not supported" % estimator,
+        error="Error: estimator %r is not supported" % estimator,
     )
 
 
@@ -33,9 +41,18 @@ def explain_prediction_lightning(estimator, doc, vec=None, top=None,
                                  feature_names=None, vectorized=False,
                                  coef_scale=None):
     """ Return an explanation of a lightning estimator predictions """
+    return explain_weights_lightning_not_supported(estimator, doc)
+
+
+@explain_prediction.register(BaseEstimator)
+def explain_prediction_lightning_not_supported(
+        estimator, doc, vec=None, top=None,
+        target_names=None, targets=None,
+        feature_names=None, vectorized=False,
+        coef_scale=None):
     return Explanation(
         estimator=repr(estimator),
-        description="Error: estimator %r is not supported" % estimator,
+        error="Error: estimator %r is not supported" % estimator,
     )
 
 

--- a/eli5/lime/lime.py
+++ b/eli5/lime/lime.py
@@ -209,6 +209,7 @@ class TextExplainer(BaseEstimator):
             doc,             # type: str
             predict_proba,   # type: Callable[[Any], Any]
             ):
+        # type: (...) -> TextExplainer
         """
         Explain ``predict_proba`` probabilistic classification function
         for the ``doc`` example. This method fits a local classification
@@ -229,7 +230,6 @@ class TextExplainer(BaseEstimator):
             probability values - a row per document and a column per output
             label.
         """
-        # type: (...) -> TextExplainer
         self.doc_ = doc
 
         if self.position_dependent:

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -61,7 +61,6 @@ from eli5._decision_path import DECISION_PATHS_CAVEATS
 from eli5._feature_weights import get_top_features
 
 
-@explain_prediction.register(BaseEstimator)
 @singledispatch
 def explain_prediction_sklearn(estimator, doc,
                                vec=None,
@@ -80,6 +79,13 @@ def explain_prediction_sklearn(estimator, doc,
     )
 
 
+def register(cls):
+    def deco(f):
+        return explain_prediction.register(cls)(
+            explain_prediction_sklearn.register(cls)(f))
+    return deco
+
+
 @explain_prediction.register(OneVsRestClassifier)
 def explain_prediction_ovr(clf, doc, **kwargs):
     estimator = clf.estimator
@@ -96,14 +102,14 @@ def explain_prediction_ovr_sklearn(clf, doc, **kwargs):
     return func(clf, doc, **kwargs)
 
 
-@explain_prediction_sklearn.register(LogisticRegression)
-@explain_prediction_sklearn.register(LogisticRegressionCV)
-@explain_prediction_sklearn.register(SGDClassifier)
-@explain_prediction_sklearn.register(PassiveAggressiveClassifier)
-@explain_prediction_sklearn.register(Perceptron)
-@explain_prediction_sklearn.register(LinearSVC)
-@explain_prediction_sklearn.register(RidgeClassifier)
-@explain_prediction_sklearn.register(RidgeClassifierCV)
+@register(LogisticRegression)
+@register(LogisticRegressionCV)
+@register(SGDClassifier)
+@register(PassiveAggressiveClassifier)
+@register(Perceptron)
+@register(LinearSVC)
+@register(RidgeClassifier)
+@register(RidgeClassifierCV)
 def explain_prediction_linear_classifier(clf, doc,
                                          vec=None,
                                          top=None,
@@ -179,20 +185,20 @@ def explain_prediction_linear_classifier(clf, doc,
     return res
 
 
-@explain_prediction_sklearn.register(ElasticNet)
-@explain_prediction_sklearn.register(ElasticNetCV)
-@explain_prediction_sklearn.register(HuberRegressor)
-@explain_prediction_sklearn.register(Lars)
-@explain_prediction_sklearn.register(LassoCV)
-@explain_prediction_sklearn.register(LinearRegression)
-@explain_prediction_sklearn.register(LinearSVR)
-@explain_prediction_sklearn.register(OrthogonalMatchingPursuit)
-@explain_prediction_sklearn.register(OrthogonalMatchingPursuitCV)
-@explain_prediction_sklearn.register(PassiveAggressiveRegressor)
-@explain_prediction_sklearn.register(Ridge)
-@explain_prediction_sklearn.register(RidgeCV)
-@explain_prediction_sklearn.register(SGDRegressor)
-@explain_prediction_sklearn.register(TheilSenRegressor)
+@register(ElasticNet)
+@register(ElasticNetCV)
+@register(HuberRegressor)
+@register(Lars)
+@register(LassoCV)
+@register(LinearRegression)
+@register(LinearSVR)
+@register(OrthogonalMatchingPursuit)
+@register(OrthogonalMatchingPursuitCV)
+@register(PassiveAggressiveRegressor)
+@register(Ridge)
+@register(RidgeCV)
+@register(SGDRegressor)
+@register(TheilSenRegressor)
 def explain_prediction_linear_regressor(reg, doc,
                                         vec=None,
                                         top=None,
@@ -290,10 +296,10 @@ Features with largest coefficients per target.
 """ + DECISION_PATHS_CAVEATS
 
 
-@explain_prediction_sklearn.register(DecisionTreeClassifier)
-@explain_prediction_sklearn.register(ExtraTreesClassifier)
-@explain_prediction_sklearn.register(GradientBoostingClassifier)
-@explain_prediction_sklearn.register(RandomForestClassifier)
+@register(DecisionTreeClassifier)
+@register(ExtraTreesClassifier)
+@register(GradientBoostingClassifier)
+@register(RandomForestClassifier)
 def explain_prediction_tree_classifier(
         clf, doc,
         vec=None,
@@ -393,10 +399,10 @@ def explain_prediction_tree_classifier(
     return res
 
 
-@explain_prediction_sklearn.register(DecisionTreeRegressor)
-@explain_prediction_sklearn.register(ExtraTreesRegressor)
-@explain_prediction_sklearn.register(GradientBoostingRegressor)
-@explain_prediction_sklearn.register(RandomForestRegressor)
+@register(DecisionTreeRegressor)
+@register(ExtraTreesRegressor)
+@register(GradientBoostingRegressor)
+@register(RandomForestRegressor)
 def explain_prediction_tree_regressor(
         reg, doc,
         vec=None,

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -73,6 +73,21 @@ def explain_prediction_sklearn(estimator, doc,
                                feature_filter=None,
                                vectorized=False):
     """ Return an explanation of a scikit-learn estimator """
+    return explain_prediction_sklearn_not_supported(estimator, doc)
+
+
+@explain_prediction.register(BaseEstimator)
+def explain_prediction_sklearn_not_supported(
+        estimator, doc,
+        vec=None,
+        top=None,
+        top_targets=None,
+        target_names=None,
+        targets=None,
+        feature_names=None,
+        feature_re=None,
+        feature_filter=None,
+        vectorized=False):
     return Explanation(
         estimator=repr(estimator),
         error="estimator %r is not supported" % estimator,

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -110,7 +110,6 @@ all values sum to 1.
 _TOP = 20
 
 
-@explain_weights.register(BaseEstimator)
 @singledispatch
 def explain_weights_sklearn(estimator, vec=None, top=_TOP,
                             target_names=None,
@@ -122,6 +121,13 @@ def explain_weights_sklearn(estimator, vec=None, top=_TOP,
         estimator=repr(estimator),
         error="estimator %r is not supported" % estimator,
     )
+
+
+def register(cls):
+    def deco(f):
+        return explain_weights.register(cls)(
+            explain_weights_sklearn.register(cls)(f))
+    return deco
 
 
 @explain_weights.register(OneVsRestClassifier)
@@ -140,14 +146,14 @@ def explain_weights_ovr_sklearn(ovr, **kwargs):
     return func(ovr, **kwargs)
 
 
-@explain_weights_sklearn.register(LogisticRegression)
-@explain_weights_sklearn.register(LogisticRegressionCV)
-@explain_weights_sklearn.register(SGDClassifier)
-@explain_weights_sklearn.register(PassiveAggressiveClassifier)
-@explain_weights_sklearn.register(Perceptron)
-@explain_weights_sklearn.register(LinearSVC)
-@explain_weights_sklearn.register(RidgeClassifier)
-@explain_weights_sklearn.register(RidgeClassifierCV)
+@register(LogisticRegression)
+@register(LogisticRegressionCV)
+@register(SGDClassifier)
+@register(PassiveAggressiveClassifier)
+@register(Perceptron)
+@register(LinearSVC)
+@register(RidgeClassifier)
+@register(RidgeClassifierCV)
 def explain_linear_classifier_weights(clf,
                                       vec=None,
                                       top=_TOP,
@@ -219,14 +225,14 @@ def explain_linear_classifier_weights(clf,
         )
 
 
-@explain_weights_sklearn.register(RandomForestClassifier)
-@explain_weights_sklearn.register(RandomForestRegressor)
-@explain_weights_sklearn.register(ExtraTreesClassifier)
-@explain_weights_sklearn.register(ExtraTreesRegressor)
-@explain_weights_sklearn.register(GradientBoostingClassifier)
-@explain_weights_sklearn.register(GradientBoostingRegressor)
-@explain_weights_sklearn.register(AdaBoostClassifier)
-@explain_weights_sklearn.register(AdaBoostRegressor)
+@register(RandomForestClassifier)
+@register(RandomForestRegressor)
+@register(ExtraTreesClassifier)
+@register(ExtraTreesRegressor)
+@register(GradientBoostingClassifier)
+@register(GradientBoostingRegressor)
+@register(AdaBoostClassifier)
+@register(AdaBoostRegressor)
 def explain_rf_feature_importance(estimator,
                                   vec=None,
                                   top=_TOP,
@@ -274,8 +280,8 @@ def explain_rf_feature_importance(estimator,
     )
 
 
-@explain_weights_sklearn.register(DecisionTreeClassifier)
-@explain_weights_sklearn.register(DecisionTreeRegressor)
+@register(DecisionTreeClassifier)
+@register(DecisionTreeRegressor)
 def explain_decision_tree(estimator,
                           vec=None,
                           top=_TOP,
@@ -332,20 +338,20 @@ def explain_decision_tree(estimator,
     )
 
 
-@explain_weights_sklearn.register(ElasticNet)
-@explain_weights_sklearn.register(ElasticNetCV)
-@explain_weights_sklearn.register(HuberRegressor)
-@explain_weights_sklearn.register(Lars)
-@explain_weights_sklearn.register(LassoCV)
-@explain_weights_sklearn.register(LinearRegression)
-@explain_weights_sklearn.register(LinearSVR)
-@explain_weights_sklearn.register(OrthogonalMatchingPursuit)
-@explain_weights_sklearn.register(OrthogonalMatchingPursuitCV)
-@explain_weights_sklearn.register(PassiveAggressiveRegressor)
-@explain_weights_sklearn.register(Ridge)
-@explain_weights_sklearn.register(RidgeCV)
-@explain_weights_sklearn.register(SGDRegressor)
-@explain_weights_sklearn.register(TheilSenRegressor)
+@register(ElasticNet)
+@register(ElasticNetCV)
+@register(HuberRegressor)
+@register(Lars)
+@register(LassoCV)
+@register(LinearRegression)
+@register(LinearSVR)
+@register(OrthogonalMatchingPursuit)
+@register(OrthogonalMatchingPursuitCV)
+@register(PassiveAggressiveRegressor)
+@register(Ridge)
+@register(RidgeCV)
+@register(SGDRegressor)
+@register(TheilSenRegressor)
 def explain_linear_regressor_weights(reg,
                                      vec=None,
                                      top=_TOP,

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -121,6 +121,16 @@ def explain_weights_sklearn(estimator, vec=None, top=_TOP,
                             feature_names=None, coef_scale=None,
                             feature_re=None, feature_filter=None):
     """ Return an explanation of an estimator """
+    return explain_weights_not_supported(estimator)
+
+
+@explain_weights.register(BaseEstimator)
+def explain_weights_not_supported(
+        estimator, vec=None, top=_TOP,
+        target_names=None,
+        targets=None,
+        feature_names=None, coef_scale=None,
+        feature_re=None, feature_filter=None):
     return Explanation(
         estimator=repr(estimator),
         error="estimator %r is not supported" % estimator,

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -154,7 +154,7 @@ def explain_weights_ovr(ovr, **kwargs):
 @explain_weights_sklearn.register(OneVsRestClassifier)
 def explain_weights_ovr_sklearn(ovr, **kwargs):
     # dispatch OvR to eli5.sklearn
-    # if explain_prediction_sklearn is called explicitly
+    # if explain_weights_sklearn is called explicitly
     estimator = ovr.estimator
     func = explain_weights_sklearn.dispatch(estimator.__class__)
     return func(ovr, **kwargs)

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -121,11 +121,11 @@ def explain_weights_sklearn(estimator, vec=None, top=_TOP,
                             feature_names=None, coef_scale=None,
                             feature_re=None, feature_filter=None):
     """ Return an explanation of an estimator """
-    return explain_weights_not_supported(estimator)
+    return explain_weights_sklearn_not_supported(estimator)
 
 
 @explain_weights.register(BaseEstimator)
-def explain_weights_not_supported(
+def explain_weights_sklearn_not_supported(
         estimator, vec=None, top=_TOP,
         target_names=None,
         targets=None,

--- a/eli5/sklearn/text.py
+++ b/eli5/sklearn/text.py
@@ -27,6 +27,7 @@ def get_weighted_spans(doc, vec, feature_weights):
                 [doc_weighted_spans],
                 other=_get_other(feature_weights, [('', found_features)]),
             )
+    return None
 
 
 def add_weighted_spans(doc, vec, vectorized, target_expl):
@@ -133,6 +134,8 @@ def _get_weighted_spans_from_union(doc, vec_union, feature_weights):
             docs_weighted_spans,
             other=_get_other(feature_weights, named_found_features),
         )
+    else:
+        return None
 
 
 def _get_other(feature_weights, named_found_features):

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -52,7 +52,6 @@ DESCRIPTION_REGRESSION = DESCRIPTION_CLF_BINARY
 
 @explain_weights.register(XGBClassifier)
 @explain_weights.register(XGBRegressor)
-@singledispatch
 def explain_weights_xgboost(xgb,
                             vec=None,
                             top=20,
@@ -110,7 +109,6 @@ def explain_weights_xgboost(xgb,
 
 @explain_prediction.register(XGBClassifier)
 @explain_prediction.register(XGBRegressor)
-@singledispatch
 def explain_prediction_xgboost(
         xgb, doc,
         vec=None,

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip('lightning')
 
 from lightning import regression
+from lightning.impl.base import BaseEstimator
 from sklearn.multiclass import OneVsRestClassifier
 
 from eli5.lightning import _CLASSIFIERS, _REGRESSORS
@@ -49,3 +50,20 @@ def test_explain_prediction_regressors(boston_train, reg):
 def test_explain_weights_regressors(boston_train, reg):
     assert_explained_weights_linear_regressor(boston_train, reg,
                                               has_bias=False)
+
+
+def test_explain_weights_unsupported():
+    clf = BaseEstimator()
+    res = explain_weights(clf)
+    assert 'BaseEstimator' in res.error
+    with pytest.raises(TypeError):
+        explain_prediction(clf, unknown_argument=True)
+
+
+def test_explain_prediction_unsupported():
+    clf = BaseEstimator()
+    doc = 'doc'
+    res = explain_prediction(clf, doc)
+    assert 'BaseEstimator' in res.error
+    with pytest.raises(TypeError):
+        explain_prediction(clf, doc, unknown_argument=True)

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -46,7 +46,7 @@ from sklearn.svm import LinearSVC, LinearSVR
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
-from eli5 import explain_prediction
+from eli5 import explain_prediction, explain_prediction_sklearn
 from eli5.formatters import format_as_text, fields
 from eli5.sklearn.utils import has_intercept
 from .utils import (
@@ -244,6 +244,9 @@ def assert_tree_explain_prediction_single_target(clf, X, feature_names):
 def test_explain_linear(newsgroups_train, clf):
     assert_multiclass_linear_classifier_explained(newsgroups_train, clf,
                                                   explain_prediction)
+    if isinstance(clf, OneVsRestClassifier):
+        assert_multiclass_linear_classifier_explained(
+            newsgroups_train, clf, explain_prediction_sklearn)
 
 
 @pytest.mark.parametrize(['reg'], [

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -4,6 +4,7 @@ from functools import partial
 from pprint import pprint
 
 import pytest
+from sklearn.base import BaseEstimator
 from sklearn.datasets import make_regression
 from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
 from sklearn.ensemble import (
@@ -362,3 +363,16 @@ def test_explain_tree_classifier_text(clf, newsgroups_train_big):
     res = explain_prediction(clf, docs[0], vec=vec, target_names=target_names)
     check_targets_scores(res)
     format_as_all(res, clf)
+
+
+def test_unsupported():
+    vec = CountVectorizer()
+    clf = BaseEstimator()
+    doc = 'doc'
+    res = explain_prediction(clf, doc, vec=vec)
+    assert 'BaseEstimator' in res.error
+    for expl in format_as_all(res, clf):
+        assert 'Error' in expl
+        assert 'BaseEstimator' in expl
+    with pytest.raises(TypeError):
+        explain_prediction(clf, doc, unknown_argument=True)

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -55,7 +55,7 @@ from sklearn.multiclass import OneVsRestClassifier
 import pytest
 
 from eli5 import _graphviz
-from eli5 import explain_weights
+from eli5 import explain_weights, explain_weights_sklearn
 from eli5.sklearn import InvertableHashingVectorizer
 from .utils import format_as_all, get_all_features, get_names_coefs
 
@@ -156,7 +156,7 @@ def test_explain_linear(newsgroups_train, clf):
 def test_explain_linear_multilabel(clf):
     X, Y = make_multilabel_classification(random_state=42)
     clf.fit(X, Y)
-    res = explain_weights(clf)
+    res = explain_weights_sklearn(clf)
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:
         assert 'y=4' in expl

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -388,6 +388,8 @@ def test_unsupported():
     for expl in format_as_all(res, clf):
         assert 'Error' in expl
         assert 'BaseEstimator' in expl
+    with pytest.raises(TypeError):
+        explain_weights(clf, unknown_argument=True)
 
 
 @pytest.mark.parametrize(['reg'], [

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands={[testenv:py35-extra]commands}
 basepython=python3.5
 deps=
     {[testenv]deps}
-    mypy-lang
+    mypy
 commands=
     mypy --check-untyped-defs eli5
 


### PR DESCRIPTION
Using `mypy` instead of `mypy-lang`. Had to work about some existing mypy issues and filed one new. At least they are all known :)
A couple of fixes were actual bugs in types: missing variants, extra commas, misplaced type annotations. Also mypy started to check None return type more strictly (it's required in type signature and explicit return None is required for Option return type).
Fixes #168 