### PR TITLE
Render spans with zero weights: test and fix

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -189,7 +189,10 @@ def _weight_opacity(weight, weight_range):
     """ Return opacity value for given weight as a string.
     """
     min_opacity = 0.8
-    rel_weight = abs(weight) / weight_range
+    if np.isclose(weight, 0) and np.isclose(weight_range, 0):
+        rel_weight = 0
+    else:
+        rel_weight = abs(weight) / weight_range
     return '{:.2f}'.format(min_opacity + (1 - min_opacity) * rel_weight)
 
 

--- a/tests/test_formatters_html.py
+++ b/tests/test_formatters_html.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+import numpy as np
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 
@@ -124,6 +125,22 @@ def test_render_weighted_spans_word():
          '<span > </span>'
          '<span  title="0.200">tree</span>'
     )
+
+
+def test_render_weighted_spans_zero():
+    weighted_spans = DocWeightedSpans(
+        document='ab',
+        spans=[('a', [(0, 1)], 0.0),
+               ('b', [(1, 2)], 0.0)],
+        preserve_density=False,
+    )
+    np_err = np.geterr()
+    np.seterr(all='raise')
+    try:
+        s = _render_weighted_spans(weighted_spans)
+    finally:
+        np.seterr(**np_err)
+    assert s == '<span style="opacity: 0.80">ab</span>'
 
 
 def test_render_weighted_spans_char():


### PR DESCRIPTION
If all weight are zero, previously a runtime warning was raised, and opacity was "nan" in html:
```
eli5/formatters/html.py:195: RuntimeWarning: invalid value encountered in double_scalars
  rel_weight = abs(weight) / weight_range
<span style="opacity: nan">ab</span>
```
Now if weights and weight range are zero, weights stay at zero.