### PR TITLE
Fix table styles for notebook>=5.0.0

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -71,11 +71,17 @@ def format_as_html(explanation, include_styles=True, force_weights=True,
     return template.render(
         include_styles=include_styles,
         force_weights=force_weights,
-        target_table_styles='border-collapse: collapse; border: none; margin-top: 0em;',
+        target_table_styles=
+        'border-collapse: collapse; border: none; margin-top: 0em; table-layout: auto;',
         tr_styles='border: none;',
+        # Weight (th and td)
         td1_styles='padding: 0 1em 0 0.5em; text-align: right; border: none;',
-        tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none;',
+        # N more positive/negative
+        tdm_styles='padding: 0 0.5em 0 0.5em; text-align: center; border: none; '
+                   'white-space: nowrap;',
+        # Feature (th and td)
         td2_styles='padding: 0 0.5em 0 0.5em; text-align: left; border: none;',
+        # Value (th and td)
         td3_styles='padding: 0 0.5em 0 1em; text-align: right; border: none;',
         horizontal_layout_table_styles=
         'border-collapse: collapse; border: none; margin-bottom: 1.5em;',


### PR DESCRIPTION
``table-layout: auto`` fixes the main issue (overrides new default of ``table-layout: fixed``), and adding ``white-space: nowrap;`` for cells with "N more positive/negative" makes the table more tidy.

here is how it looks for full 20 newsgroups dataset:
![image](https://cloud.githubusercontent.com/assets/424613/25650976/222f39aa-2fe9-11e7-86ed-f6dca0696a20.png)

Fixes #178 