### PR TITLE
Fix explain_weights for Lasso with one feature

### DIFF
--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -124,7 +124,7 @@ def get_default_target_names(estimator, num_targets=None):
     and "y0", "y1", ... if there are multiple targets.
     """
     if num_targets is None:
-        if len(estimator.coef_.shape) == 1:
+        if len(estimator.coef_.shape) <= 1:
             num_targets = 1
         else:
             num_targets, _ = estimator.coef_.shape
@@ -152,6 +152,9 @@ def get_coef(clf, label_id, scale=None):
             raise ValueError(
                 'Unexpected label_id %s for 1D coefficient' % label_id)
         coef = clf.coef_
+    elif len(clf.coef_.shape) == 0:
+        # Lasso with one feature: 0D array
+        coef = np.array([clf.coef_])
     else:
         raise ValueError('Unexpected clf.coef_ shape: %s' % clf.coef_.shape)
 
@@ -177,6 +180,8 @@ def get_coef(clf, label_id, scale=None):
 def get_num_features(estimator):
     """ Return size of a feature vector estimator expects as an input. """
     if hasattr(estimator, 'coef_'):  # linear models
+        if len(estimator.coef_.shape) == 0:
+            return 1
         return estimator.coef_.shape[-1]
     elif hasattr(estimator, 'feature_importances_'):  # ensembles
         return estimator.feature_importances_.shape[-1]

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -421,6 +421,26 @@ def test_explain_linear_regression(boston_train, reg):
     assert_explained_weights_linear_regressor(boston_train, reg)
 
 
+@pytest.mark.parametrize(['reg'], [
+    [Lasso()],
+    [Lasso(fit_intercept=False)],
+    [LinearRegression()],
+    [LinearRegression(fit_intercept=False)],
+])
+def test_explain_linear_regression_one_feature(reg):
+    xs, ys = make_regression(n_samples=10, n_features=1, bias=7.5)
+    reg.fit(xs, ys)
+    res = explain_weights(reg)
+    expl_text, expl_html = format_as_all(res, reg)
+
+    for expl in [expl_text, expl_html]:
+        assert 'x0' in expl
+
+    if reg.fit_intercept:
+        assert '<BIAS>' in expl_text
+        assert '&lt;BIAS&gt;' in expl_html
+
+
 def test_explain_linear_regression_feature_filter(boston_train):
     clf = ElasticNet(random_state=42)
     X, y, feature_names = boston_train


### PR DESCRIPTION
It uses a scalar to store it's weights - this might apply to some other estimators too. Fixes #180 