### PR TITLE
explain_prediction with pandas

### DIFF
--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -97,8 +97,8 @@ def explain_prediction(estimator, doc, **kwargs):
         Example to run estimator on. Estimator makes a prediction for this
         example, and :func:`explain_prediction` tries to show information
         about this prediction. Pass a single element, not a one-element array:
-        if you fitted your estimator on ``xs``, that would be ``xs[i]`` for
-        most containers, and ``xs.iloc[i]`` for ``pandas.DataFrame``.
+        if you fitted your estimator on ``X``, that would be ``X[i]`` for
+        most containers, and ``X.iloc[i]`` for ``pandas.DataFrame``.
 
     top : int or (int, int) tuple, optional
         Number of features to show. When ``top`` is int, ``top`` features with

--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -96,7 +96,9 @@ def explain_prediction(estimator, doc, **kwargs):
     doc : object
         Example to run estimator on. Estimator makes a prediction for this
         example, and :func:`explain_prediction` tries to show information
-        about this prediction.
+        about this prediction. Pass a single element, not a one-element array:
+        if you fitted your estimator on ``xs``, that would be ``xs[i]`` for
+        most containers, and ``xs.iloc[i]`` for ``pandas.DataFrame``.
 
     top : int or (int, int) tuple, optional
         Number of features to show. When ``top`` is int, ``top`` features with

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -140,8 +140,8 @@ def show_prediction(estimator, doc, **kwargs):
         Example to run estimator on. Estimator makes a prediction for this
         example, and :func:`show_prediction` tries to show information
         about this prediction. Pass a single element, not a one-element array:
-        if you fitted your estimator on ``xs``, that would be ``xs[i]`` for
-        most containers, and ``xs.iloc[i]`` for ``pandas.DataFrame``.
+        if you fitted your estimator on ``X``, that would be ``X[i]`` for
+        most containers, and ``X.iloc[i]`` for ``pandas.DataFrame``.
 
     top : int or (int, int) tuple, optional
         Number of features to show. When ``top`` is int, ``top`` features with

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -139,7 +139,9 @@ def show_prediction(estimator, doc, **kwargs):
     doc : object
         Example to run estimator on. Estimator makes a prediction for this
         example, and :func:`show_prediction` tries to show information
-        about this prediction.
+        about this prediction. Pass a single element, not a one-element array:
+        if you fitted your estimator on ``xs``, that would be ``xs[i]`` for
+        most containers, and ``xs.iloc[i]`` for ``pandas.DataFrame``.
 
     top : int or (int, int) tuple, optional
         Number of features to show. When ``top`` is int, ``top`` features with

--- a/eli5/lightgbm.py
+++ b/eli5/lightgbm.py
@@ -9,7 +9,7 @@ import lightgbm  # type: ignore
 from eli5._feature_weights import get_top_features
 from eli5.explain import explain_weights, explain_prediction
 from eli5._feature_importances import get_feature_importance_explanation
-from eli5.sklearn.utils import handle_vec, get_X, add_intercept, predict_proba
+from eli5.sklearn.utils import handle_vec, get_X, get_X0, add_intercept, predict_proba
 from eli5.utils import mask
 from eli5._decision_path import get_decision_path_explanation
 
@@ -117,7 +117,7 @@ def explain_prediction_lightgbm(
 
     proba = predict_proba(lgb, X)
     weight_dicts = _get_prediction_feature_weights(lgb, X, _lgb_n_targets(lgb))
-    x, = add_intercept(X)
+    x = get_X0(add_intercept(X))
     flt_feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -49,6 +49,7 @@ from eli5.sklearn.utils import (
     get_coef,
     get_default_target_names,
     get_X,
+    get_X0,
     is_multiclass_classifier,
     is_multitarget_regressor,
     predict_proba,
@@ -162,7 +163,7 @@ def explain_prediction_linear_classifier(clf, doc,
 
     if has_intercept(clf):
         X = add_intercept(X)
-    x, = X
+    x = get_X0(X)
 
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
@@ -248,7 +249,7 @@ def explain_prediction_linear_regressor(reg, doc,
 
     if has_intercept(reg):
         X = add_intercept(X)
-    x, = X
+    x = get_X0(X)
 
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
@@ -367,7 +368,7 @@ def explain_prediction_tree_classifier(
     is_multiclass = clf.n_classes_ > 2
     feature_weights = _trees_feature_weights(
         clf, X, feature_names, clf.n_classes_)
-    x, = add_intercept(X)
+    x = get_X0(add_intercept(X))
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
 
@@ -465,7 +466,7 @@ def explain_prediction_tree_regressor(
     num_targets = getattr(reg, 'n_outputs_', 1)
     is_multitarget = num_targets > 1
     feature_weights = _trees_feature_weights(reg, X, feature_names, num_targets)
-    x, = add_intercept(X)
+    x = get_X0(add_intercept(X))
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
 

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -220,14 +220,14 @@ def get_X(doc, vec=None, vectorized=False, to_dense=False):
     return X
 
 
-def get_X0(xs):
+def get_X0(X):
     """ Return zero-th element of a one-element data container.
     """
-    if pandas_available and isinstance(xs, pd.DataFrame):
-        assert len(xs) == 1
-        x = np.array(xs.iloc[0])
+    if pandas_available and isinstance(X, pd.DataFrame):
+        assert len(X) == 1
+        x = np.array(X.iloc[0])
     else:
-        x, = xs
+        x, = X
     return x
 
 

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -198,7 +198,7 @@ def get_num_features(estimator):
 
 
 try:
-    import pandas as pd
+    import pandas as pd  # type: ignore
     pandas_available = True
 except ImportError:
     pandas_available = False
@@ -218,6 +218,17 @@ def get_X(doc, vec=None, vectorized=False, to_dense=False):
     if to_dense and sp.issparse(X):
         X = X.toarray()
     return X
+
+
+def get_X0(xs):
+    """ Return zero-th element of a one-element data container.
+    """
+    if pandas_available and isinstance(xs, pd.DataFrame):
+        assert len(xs) == 1
+        x = np.array(xs.iloc[0])
+    else:
+        x, = xs
+    return x
 
 
 def handle_vec(clf, doc, vec, vectorized, feature_names, num_features=None):

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -17,6 +17,7 @@ from eli5.explain import explain_weights, explain_prediction
 from eli5.sklearn.utils import (
     add_intercept,
     get_X,
+    get_X0,
     handle_vec,
     predict_proba
 )
@@ -137,7 +138,7 @@ def explain_prediction_xgboost(
     scores_weights = _prediction_feature_weights(
         xgb, X, feature_names, xgb_feature_names)
 
-    x, = add_intercept(X)
+    x = get_X0(add_intercept(X))
     x = _missing_values_set_to_nan(x, xgb.missing, sparse_missing=True)
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 from functools import partial
 import re
-from singledispatch import singledispatch
 from typing import Any, Dict, List, Tuple
 
 import numpy as np  # type: ignore
@@ -120,9 +119,9 @@ def explain_prediction_xgboost(
     changes from parent to child.
     Weights of all features sum to the output score of the estimator.
     """
-    num_features = len(xgb.booster().feature_names)
+    xgb_feature_names = xgb.booster().feature_names
     vec, feature_names = handle_vec(
-        xgb, doc, vec, vectorized, feature_names, num_features=num_features)
+        xgb, doc, vec, vectorized, feature_names, num_features=len(xgb_feature_names))
     if feature_names.bias_name is None:
         # XGBoost estimators do not have an intercept, but here we interpret
         # them as having an intercept
@@ -135,7 +134,8 @@ def explain_prediction_xgboost(
         X = X.tocsc()
 
     proba = predict_proba(xgb, X)
-    scores_weights = _prediction_feature_weights(xgb, X, feature_names)
+    scores_weights = _prediction_feature_weights(
+        xgb, X, feature_names, xgb_feature_names)
 
     x, = add_intercept(X)
     x = _missing_values_set_to_nan(x, xgb.missing, sparse_missing=True)
@@ -169,7 +169,7 @@ def explain_prediction_xgboost(
      )
 
 
-def _prediction_feature_weights(xgb, X, feature_names):
+def _prediction_feature_weights(xgb, X, feature_names, xgb_feature_names):
     """ For each target, return score and numpy array with feature weights
     on this prediction, following an idea from
     http://blog.datadive.net/interpreting-random-forests/
@@ -177,11 +177,13 @@ def _prediction_feature_weights(xgb, X, feature_names):
     # XGBClassifier does not have pred_leaf argument, so use booster
     booster = xgb.booster()  # type: Booster
     leaf_ids, = booster.predict(DMatrix(X, missing=xgb.missing), pred_leaf=True)
+    xgb_feature_names = {f: i for i, f in enumerate(xgb_feature_names)}
     tree_dumps = booster.get_dump(with_stats=True)
     assert len(tree_dumps) == len(leaf_ids)
 
     target_feature_weights = partial(
-        _target_feature_weights, feature_names=feature_names)
+        _target_feature_weights,
+        feature_names=feature_names, xgb_feature_names=xgb_feature_names)
     n_targets = _xgb_n_targets(xgb)
     if n_targets > 1:
         # For multiclass, XGBoost stores dumps and leaf_ids in a 1d array,
@@ -196,7 +198,7 @@ def _prediction_feature_weights(xgb, X, feature_names):
     return scores_weights
 
 
-def _target_feature_weights(leaf_ids, tree_dumps, feature_names):
+def _target_feature_weights(leaf_ids, tree_dumps, feature_names, xgb_feature_names):
     feature_weights = np.zeros(len(feature_names))
     # All trees in XGBoost give equal contribution to the prediction:
     # it is equal to sum of "leaf" values in leafs
@@ -212,8 +214,7 @@ def _target_feature_weights(leaf_ids, tree_dumps, feature_names):
         path.reverse()
         # Check how each split changes "leaf" value
         for node, child in zip(path, path[1:]):
-            f_num_match = re.search('^f(\d+)$', node['split'])
-            idx = int(f_num_match.groups()[0])
+            idx = xgb_feature_names[node['split']]
             feature_weights[idx] += child['leaf'] - node['leaf']
         # Root "leaf" value is interpreted as bias
         feature_weights[feature_names.bias_idx] += path[0]['leaf']

--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -16,7 +16,10 @@ from .test_sklearn_explain_weights import (
     test_feature_importances_no_remaining as _check_rf_no_remaining,
     test_explain_tree_regressor as _check_rf_regressor,
 )
-from .test_sklearn_explain_prediction import assert_linear_regression_explained
+from .test_sklearn_explain_prediction import (
+    assert_linear_regression_explained,
+    test_explain_prediction_pandas as _check_explain_prediction_pandas,
+)
 from .utils import format_as_all, check_targets_scores, get_all_features
 
 
@@ -108,3 +111,7 @@ def test_explain_prediction_regression(boston_train):
     assert_linear_regression_explained(
         boston_train, LGBMRegressor(), explain_prediction,
         reg_has_intercept=True)
+
+
+def test_explain_prediction_pandas(boston_train):
+    _check_explain_prediction_pandas(LGBMRegressor(), boston_train)

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -16,6 +16,7 @@ from eli5 import (
 from .test_sklearn_explain_prediction import (
     assert_multiclass_linear_classifier_explained,
     assert_linear_regression_explained,
+    test_explain_prediction_pandas as _check_explain_prediction_pandas,
 )
 from .test_sklearn_explain_weights import (
     assert_explained_weights_linear_classifier,
@@ -60,6 +61,11 @@ def test_explain_prediction_regressors(boston_train, reg):
 def test_explain_weights_regressors(boston_train, reg):
     assert_explained_weights_linear_regressor(boston_train, reg,
                                               has_bias=False)
+
+
+@pytest.mark.parametrize(['reg'], regressor_params[:2])
+def test_explain_prediction_pandas(reg, boston_train):
+    _check_explain_prediction_pandas(reg, boston_train)
 
 
 def test_explain_weights_unsupported():

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -174,10 +174,12 @@ def assert_multitarget_linear_regression_explained(reg, explain_prediction):
     pos, neg = (get_all_features(target.feature_weights.pos),
                 get_all_features(target.feature_weights.neg))
     assert 'x8' in pos or 'x8' in neg
-    assert '<BIAS>' in pos or '<BIAS>' in neg
+    if has_intercept(reg):
+        assert '<BIAS>' in pos or '<BIAS>' in neg
 
     assert 'x8' in expl_text
-    assert '<BIAS>' in expl_text
+    if has_intercept(reg):
+        assert '<BIAS>' in expl_text
     assert "'y2'" in expl_text
 
     assert res == explain_prediction(reg, X[0])
@@ -261,6 +263,7 @@ def test_explain_linear(newsgroups_train, clf):
     [LassoLarsCV(max_n_alphas=10)],
     [LassoLarsIC()],
     [LinearRegression()],
+    [LinearRegression(fit_intercept=False)],
     [LinearSVR(random_state=42)],
     [OrthogonalMatchingPursuit(n_nonzero_coefs=10)],
     [OrthogonalMatchingPursuitCV()],
@@ -279,6 +282,7 @@ def test_explain_linear_regression(boston_train, reg):
     [Lars()],
     [Lasso(random_state=42)],
     [LinearRegression()],
+    [LinearRegression(fit_intercept=False)],
     [Ridge(random_state=42)],
 ])
 def test_explain_linear_regression_multitarget(reg):
@@ -383,6 +387,7 @@ def test_unsupported():
 
 @pytest.mark.parametrize(['reg'], [
     [LinearRegression()],
+    [LinearRegression(fit_intercept=False)],
     [RandomForestRegressor(random_state=42)],
 ])
 def test_explain_prediction_pandas(reg, boston_train):
@@ -393,4 +398,5 @@ def test_explain_prediction_pandas(reg, boston_train):
     res = explain_prediction(reg, df.iloc[0])
     for expl in format_as_all(res, reg):
         assert 'PTRATIO' in expl
-        assert 'BIAS' in expl
+        if has_intercept(reg):
+            assert 'BIAS' in expl

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -379,3 +379,18 @@ def test_unsupported():
         assert 'BaseEstimator' in expl
     with pytest.raises(TypeError):
         explain_prediction(clf, doc, unknown_argument=True)
+
+
+@pytest.mark.parametrize(['reg'], [
+    [LinearRegression()],
+    [RandomForestRegressor(random_state=42)],
+])
+def test_explain_prediction_pandas(reg, boston_train):
+    pd = pytest.importorskip('pandas')
+    X, y, feature_names = boston_train
+    df = pd.DataFrame(X, columns=feature_names)
+    reg.fit(df, y)
+    res = explain_prediction(reg, df.iloc[0])
+    for expl in format_as_all(res, reg):
+        assert 'PTRATIO' in expl
+        assert 'BIAS' in expl

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -22,7 +22,10 @@ from .test_sklearn_explain_weights import (
     test_explain_random_forest_and_tree_feature_filter as _check_rf_feature_filter,
     test_feature_importances_no_remaining as _check_rf_no_remaining,
 )
-from .test_sklearn_explain_prediction import assert_linear_regression_explained
+from .test_sklearn_explain_prediction import (
+    assert_linear_regression_explained,
+    test_explain_prediction_pandas as _check_explain_prediction_pandas,
+)
 
 
 def test_explain_xgboost(newsgroups_train):
@@ -208,6 +211,10 @@ def test_explain_prediction_feature_union_sparse(newsgroups_train_binary):
     pos_features = get_all_features(weights.pos)
     assert 'word__graphics' in pos_features
     assert res.targets[0].weighted_spans
+
+
+def test_explain_prediction_pandas(boston_train):
+    _check_explain_prediction_pandas(XGBRegressor(), boston_train)
 
 
 def test_parse_tree_dump():

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps=
     pytest-cov
     hypothesis[numpy] !=3.5.1, !=3.5.0
     numpy
+    pandas
     scipy
     scikit-learn
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps=
     pytest-cov
     hypothesis[numpy] !=3.5.1, !=3.5.0
     numpy
-    pandas
     scipy
     scikit-learn
 
@@ -29,6 +28,7 @@ deps=
     {[base]deps}
     sklearn-crfsuite
     ipython
+    pandas
 
 commands=
     ; to install lightning numpy must be installed first


### PR DESCRIPTION
Fixes #167 

Convert dataframe row (Series) to a dataframe with a single element.
XGBoost expects feature names to stay the same, so you can't train it on a dataframe and then pass a numpy array: there will be a feature name mismatch. This is why we need to make it a dataframe, not convert to a 2d numpy array.

Also make determining xgboost feature indices more robust: instead of parsing "f123" strings, look them up in a dictionary of feature names.

TODO:
- [x] check how pandas works with lightning
- [x] check how pandas works with lightgbm
- [x] mention pandas support in the docs and give an example