### PR TITLE
Faster pandas build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
     - if [[ "$LIGHTGBM" = 1 ]]; then bash _ci/install_lightgbm_linux.sh; export LIGHTGBM_CHECKOUT=LightGBM; fi
 
 install:
-    - pip install -U pip tox codecov
+    - pip install -U pip wheel tox codecov
 
 script: tox
 


### PR DESCRIPTION
Now the tox step is taking about 110 s instead of 718 s. Pandas has wheels available for all python versions we need, it was just not picked up without the wheel package it seems.

So the builds are back to 3-4 minutes with this PR.