### PR TITLE
Faster pandas build, take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
     - if [[ "$LIGHTGBM" = 1 ]]; then bash _ci/install_lightgbm_linux.sh; export LIGHTGBM_CHECKOUT=LightGBM; fi
 
 install:
-    - pip install -U pip wheel tox codecov
+    - pip install -U pip tox codecov
 
 script: tox
 


### PR DESCRIPTION
This undoes #189 - ``pip`` is able to pick up wheels without ``wheel`` package, and pandas is going to have binary wheels available in the future at the same time as new source release:
https://github.com/pandas-dev/pandas/issues/16260
So we just had some coincidences: adding pandas to our tests, pandas pushing a source release without wheels, and then they fixed them and I pushed an unrelated "fix" :) Sorry for a false fix in #189 
