### PR TITLE
Fix attrs test: see GH-199

### DIFF
--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -38,6 +38,9 @@ def test_attrs_without_default():
 
 
 def test_attrs_with_repr():
+    """ Check that if __repr__ or __hash__ is defined, attrs does not override
+    them (there is a special logic for it in @attrs).
+    """
 
     @attrs
     class WithRepr(object):
@@ -47,11 +50,17 @@ def test_attrs_with_repr():
         def __repr__(self):
             return 'foo'
 
-    # assert hash(WithRepr(1)) == hash(WithRepr(1))
+        def __hash__(self):
+            return 1
+
+    assert WithRepr(1) == WithRepr(1) != WithRepr(2)
     assert repr(WithRepr(2)) == 'foo'
+    assert hash(WithRepr(2)) == 1
 
 
 def test_bad_init():
+    """ Constructor argument names must match attribute names.
+    """
 
     @attrs
     class BadInit(object):


### PR DESCRIPTION
Fixes #199 

This test is meant to check code that makes sure magic methods defined in the class take precedence over attrs-defined ones.

So I think previous ``hash`` was just a mistake - I meant to define some custom ``__hash__`` but forgot about it. I checked that the changed test passes on new attrs as well as on 1.16.3. I also added docstrings to two tricky tests.