### PR TITLE
Support xgboost.Booster

### DIFF
--- a/docs/source/libraries/xgboost.rst
+++ b/docs/source/libraries/xgboost.rst
@@ -13,13 +13,8 @@ xgboost >= 0.6a2.
 .. _XGBRegressor: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor
 .. _Booster: http://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.Booster
 
-:func:`eli5.explain_weights` uses feature importances.
-There is one additional required argument for Booster_ estimator:
-
-* ``is_regression`` True if solving a regression problem
-  ("objective" starts with "reg") and False for a classification problem.
-
-Additional optional arguments for XGBClassifer_, XGBRegressor_ and Booster_:
+:func:`eli5.explain_weights` uses feature importances. Additional
+arguments for XGBClassifer_, XGBRegressor_ and Booster_:
 
 * ``importance_type`` is a way to get feature importance. Possible values are:
 
@@ -43,18 +38,13 @@ of an ensemble. Each node of the tree has an output score, and
 contribution of a feature on the decision path is how much the score changes
 from parent to child.
 
-There is one additional required argument for the Booster_ estimator:
-
-* ``is_regression`` True if solving a regression problem
-  ("objective" starts with "reg") and False for a classification problem.
-
 .. note::
     When explaining Booster_ predictions,
     do not pass an ``xgboost.DMatrix`` object as ``doc``, pass a numpy array
     or a sparse matrix instead (or have ``vec`` return them).
 
 Additional :func:`eli5.explain_prediction` keyword arguments supported
-for XGBClassifer_ and XGBRegressor_:
+for XGBClassifer_, XGBRegressor_ and Booster_:
 
 * ``vec`` is a vectorizer instance used to transform
   raw features to the input of the estimator ``xgb``
@@ -66,6 +56,17 @@ for XGBClassifer_ and XGBRegressor_:
   if ``vec`` is not None, ``vec.transform([doc])`` is passed to the
   estimator. Set it to True if you're passing ``vec``,
   but ``doc`` is already vectorized.
+
+Booster_ estimator accepts two more optional arguments:
+
+* ``is_regression`` - True if solving a regression problem
+  ("objective" starts with "reg")
+  and False for a classification problem.
+  If not set, regression is assumed for a single target estimator
+  and proba will not be shown.
+* ``missing`` - set it to the same value as the ``missing`` argument to
+  ``xgboost.DMatrix``. Matters only if sparse values are used.
+  Default is ``np.nan``.
 
 See the :ref:`tutorial <xgboost-titanic-tutorial>` for a more detailed usage
 example.

--- a/docs/source/libraries/xgboost.rst
+++ b/docs/source/libraries/xgboost.rst
@@ -5,15 +5,21 @@ XGBoost
 
 XGBoost_ is a popular Gradient Boosting library with Python interface.
 eli5 supports :func:`eli5.explain_weights` and :func:`eli5.explain_prediction`
-for XGBClassifer_ and XGBRegressor_ estimators. It is tested for
+for XGBClassifer_, XGBRegressor_ and Booster_ estimators. It is tested for
 xgboost >= 0.6a2.
 
 .. _XGBoost: https://github.com/dmlc/xgboost
 .. _XGBClassifer: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBClassifier
 .. _XGBRegressor: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor
+.. _Booster: http://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.Booster
 
-:func:`eli5.explain_weights` uses feature importances. Additional
-arguments for XGBClassifer_ and XGBRegressor_:
+:func:`eli5.explain_weights` uses feature importances.
+There is one additional required argument for Booster_ estimator:
+
+* ``is_regression`` True if solving a regression problem
+  ("objective" starts with "reg") and False for a classification problem.
+
+Additional optional arguments for XGBClassifer_, XGBRegressor_ and Booster_:
 
 * ``importance_type`` is a way to get feature importance. Possible values are:
 
@@ -36,6 +42,16 @@ feature weights are calculated by following decision paths in trees
 of an ensemble. Each node of the tree has an output score, and
 contribution of a feature on the decision path is how much the score changes
 from parent to child.
+
+There is one additional required argument for the Booster_ estimator:
+
+* ``is_regression`` True if solving a regression problem
+  ("objective" starts with "reg") and False for a classification problem.
+
+.. note::
+    When explaining Booster_ predictions,
+    do not pass an ``xgboost.DMatrix`` object as ``doc``, pass a numpy array
+    or a sparse matrix instead (or have ``vec`` return them).
 
 Additional :func:`eli5.explain_prediction` keyword arguments supported
 for XGBClassifer_ and XGBRegressor_:

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -155,10 +155,10 @@ def explain_prediction_xgboost(
             proba = None
         else:
             if n_targets == 1:
-                p = prediction[0]
+                p, = prediction
                 proba = np.array([1 - p, p])
             else:
-                proba = prediction[0]
+                proba, = prediction
     else:
         proba = predict_proba(xgb, X)
         n_targets = _xgb_n_targets(xgb)

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -150,8 +150,15 @@ def explain_prediction_xgboost(
 
     if isinstance(xgb, Booster):
         prediction = xgb.predict(dmatrix)
-        proba = None if is_regression else prediction
         n_targets = prediction.shape[-1]
+        if is_regression:
+            proba = None
+        else:
+            if n_targets == 1:
+                p = prediction[0]
+                proba = np.array([1 - p, p])
+            else:
+                proba = prediction[0]
     else:
         proba = predict_proba(xgb, X)
         n_targets = _xgb_n_targets(xgb)
@@ -167,7 +174,7 @@ def explain_prediction_xgboost(
     if is_regression:
         names = ['y']
     elif isinstance(xgb, Booster):
-        assert False  # TODO
+        names = np.arange(max(2, n_targets))
     else:
         names = xgb.classes_
 

--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -49,7 +49,8 @@ def explain_weights_xgboost(xgb,
                             ):
     """
     Return an explanation of an XGBoost estimator (via scikit-learn wrapper
-    XGBClassifier or XGBRegressor) as feature importances.
+    XGBClassifier or XGBRegressor, or via xgboost.Booster)
+    as feature importances.
 
     See :func:`eli5.explain_weights` for description of
     ``top``, ``feature_names``,
@@ -67,6 +68,10 @@ def explain_weights_xgboost(xgb,
         - 'weight' - the number of times a feature is used to split the data
           across all trees
         - 'cover' - the average coverage of the feature when it is used in trees
+
+    is_regression : bool, required only if ``xgboost.Booster`` is passed
+        True if solving a regression problem ("objective" starts with "reg")
+        and False for a classification problem.
     """
     booster, is_regression = _check_booster_args(xgb, is_regression)
     xgb_feature_names = booster.feature_names
@@ -102,22 +107,31 @@ def explain_prediction_xgboost(
         missing=None,
         ):
     """ Return an explanation of XGBoost prediction (via scikit-learn wrapper
-    XGBClassifier or XGBRegressor) as feature weights.
+    XGBClassifier or XGBRegressor, or via xgboost.Booster) as feature weights.
 
     See :func:`eli5.explain_prediction` for description of
     ``top``, ``top_targets``, ``target_names``, ``targets``,
     ``feature_names``, ``feature_re`` and ``feature_filter`` parameters.
 
-    ``vec`` is a vectorizer instance used to transform
-    raw features to the input of the estimator ``xgb``
-    (e.g. a fitted CountVectorizer instance); you can pass it
-    instead of ``feature_names``.
+    Parameters
+    ----------
+    vec : vectorizer, optional
+        A vectorizer instance used to transform
+        raw features to the input of the estimator ``xgb``
+        (e.g. a fitted CountVectorizer instance); you can pass it
+        instead of ``feature_names``.
 
-    ``vectorized`` is a flag which tells eli5 if ``doc`` should be
-    passed through ``vec`` or not. By default it is False, meaning that
-    if ``vec`` is not None, ``vec.transform([doc])`` is passed to the
-    estimator. Set it to True if you're passing ``vec``,
-    but ``doc`` is already vectorized.
+    vectorized : bool, optional
+        A flag which tells eli5 if ``doc`` should be
+        passed through ``vec`` or not. By default it is False, meaning that
+        if ``vec`` is not None, ``vec.transform([doc])`` is passed to the
+        estimator. Set it to True if you're passing ``vec``,
+        but ``doc`` is already vectorized.
+
+    is_regression : bool, required only if ``xgboost.Booster`` is passed
+        True if solving a regression problem ("objective" starts with "reg")
+        and False for a classification problem.
+
 
     Method for determining feature importances follows an idea from
     http://blog.datadive.net/interpreting-random-forests/.

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -121,8 +121,8 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
 
 def assert_trained_linear_regression_explained(
         x, feature_names, reg, explain_prediction,
-        atol=1e-8, reg_has_intercept=None):
-    res = explain_prediction(reg, x, feature_names=feature_names)
+        atol=1e-8, reg_has_intercept=None, **explain_kwargs):
+    res = explain_prediction(reg, x, feature_names=feature_names, **explain_kwargs)
     expl_text, expl_html = expls = format_as_all(res, reg)
 
     assert len(res.targets) == 1
@@ -152,13 +152,15 @@ def assert_trained_linear_regression_explained(
     assert '<b>y</b>' in strip_blanks(expl_html)
 
     for expl in expls:
-        assert_feature_values_present(expl, feature_names, X[0])
+        assert_feature_values_present(expl, feature_names, x)
 
-    assert res == explain_prediction(reg, X[0], feature_names=feature_names)
+    assert res == explain_prediction(reg, x, feature_names=feature_names,
+                                     **explain_kwargs)
     check_targets_scores(res, atol=atol)
 
-    flt_res = explain_prediction(reg, X[0], feature_names=feature_names,
-                                 feature_filter=lambda name, v: name != 'LSTAT')
+    flt_res = explain_prediction(reg, x, feature_names=feature_names,
+                                 feature_filter=lambda name, v: name != 'LSTAT',
+                                 **explain_kwargs)
     format_as_all(flt_res, reg)
     flt_target = flt_res.targets[0]
     flt_pos, flt_neg = get_pos_neg_features(flt_target.feature_weights)

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -122,8 +122,8 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
 
 def assert_trained_linear_regression_explained(
         x, feature_names, reg, explain_prediction,
-        atol=1e-8, reg_has_intercept=None, **explain_kwargs):
-    res = explain_prediction(reg, x, feature_names=feature_names, **explain_kwargs)
+        atol=1e-8, reg_has_intercept=None):
+    res = explain_prediction(reg, x, feature_names=feature_names)
     expl_text, expl_html = expls = format_as_all(res, reg)
 
     assert len(res.targets) == 1
@@ -155,13 +155,11 @@ def assert_trained_linear_regression_explained(
     for expl in expls:
         assert_feature_values_present(expl, feature_names, x)
 
-    assert res == explain_prediction(reg, x, feature_names=feature_names,
-                                     **explain_kwargs)
+    assert res == explain_prediction(reg, x, feature_names=feature_names)
     check_targets_scores(res, atol=atol)
 
     flt_res = explain_prediction(reg, x, feature_names=feature_names,
-                                 feature_filter=lambda name, v: name != 'LSTAT',
-                                 **explain_kwargs)
+                                 feature_filter=lambda name, v: name != 'LSTAT')
     format_as_all(flt_res, reg)
     flt_target = flt_res.targets[0]
     flt_pos, flt_neg = get_pos_neg_features(flt_target.feature_weights)

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 from functools import partial
 from pprint import pprint
+import re
 
 import pytest
 from sklearn.base import BaseEstimator
@@ -203,8 +204,8 @@ def assert_feature_values_present(expl, feature_names, x):
     assert 'Value' in expl
     any_features = False
     for feature, value in zip(feature_names, x):
-        if feature in expl:
-            assert '{:.3f}'.format(value) in expl
+        if re.search(r'[\b\s]{}[\b\s]'.format(re.escape(feature)), expl):
+            assert '{:.3f}'.format(value) in expl, feature
             any_features = True
     assert any_features
 

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -114,7 +114,15 @@ def assert_linear_regression_explained(boston_train, reg, explain_prediction,
                                        atol=1e-8, reg_has_intercept=None):
     X, y, feature_names = boston_train
     reg.fit(X, y)
-    res = explain_prediction(reg, X[0], feature_names=feature_names)
+    assert_trained_linear_regression_explained(
+        X[0], feature_names, reg, explain_prediction,
+        atol=atol, reg_has_intercept=reg_has_intercept)
+
+
+def assert_trained_linear_regression_explained(
+        x, feature_names, reg, explain_prediction,
+        atol=1e-8, reg_has_intercept=None):
+    res = explain_prediction(reg, x, feature_names=feature_names)
     expl_text, expl_html = expls = format_as_all(res, reg)
 
     assert len(res.targets) == 1

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -309,10 +309,13 @@ def test_explain_tree_classifier(newsgroups_train, clf):
     vec = CountVectorizer()
     X = vec.fit_transform(docs)
     clf.fit(X.toarray(), y)
+    assert_tree_classifier_explained(clf, vec, target_names)
 
+
+def assert_tree_classifier_explained(clf, vec, target_names, **explain_kwargs):
     top = 30
     get_res = lambda: explain_weights(
-        clf, vec=vec, target_names=target_names, top=top)
+        clf, vec=vec, target_names=target_names, top=top, **explain_kwargs)
     res = get_res()
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -82,6 +82,23 @@ def test_explain_xgboost_booster(boston_train):
         assert 'LSTAT' in expl
 
 
+def test_bad_regression_for_booster(boston_train):
+    xs, ys, feature_names = boston_train
+    booster = xgboost.train(
+        params={'objective': 'reg:linear', 'silent': True},
+        dtrain=xgboost.DMatrix(xs, label=ys),
+    )
+    with pytest.raises(ValueError):
+        explain_weights(booster)
+    explain_weights(booster, is_regression=True)
+    clf = XGBRegressor()
+    clf.fit(xs, ys)
+    with pytest.raises(ValueError):
+        explain_weights(clf, is_regression=False)
+    explain_weights(clf, is_regression=True)
+    explain_weights(clf)
+
+
 @pytest.mark.parametrize(
     ['missing', 'use_booster'],
     [[np.nan, False], [0, False], [np.nan, True]])

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -6,6 +6,7 @@ import numpy as np
 import scipy.sparse as sp
 from sklearn.feature_extraction.text import CountVectorizer
 pytest.importorskip('xgboost')
+import xgboost
 from xgboost import XGBClassifier, XGBRegressor
 from sklearn.pipeline import FeatureUnion
 from sklearn.preprocessing import FunctionTransformer
@@ -50,6 +51,23 @@ def test_explain_xgboost_regressor(boston_train):
         assert 'f12' in expl
     res = explain_weights(reg, feature_names=feature_names)
     for expl in format_as_all(res, reg):
+        assert 'LSTAT' in expl
+
+
+def test_explain_xgboost_booster(boston_train):
+    xs, ys, feature_names = boston_train
+    booster = xgboost.train(
+        params={
+            'objective': 'reg:linear',
+            'silent': True,
+        },
+        dtrain=xgboost.DMatrix(xs, label=ys),
+    )
+    res = explain_weights(booster)
+    for expl in format_as_all(res, booster):
+        assert 'f12' in expl
+    res = explain_weights(booster, feature_names=feature_names)
+    for expl in format_as_all(res, booster):
         assert 'LSTAT' in expl
 
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -74,10 +74,10 @@ def test_explain_xgboost_booster(boston_train):
         params={'objective': 'reg:linear', 'silent': True},
         dtrain=xgboost.DMatrix(xs, label=ys),
     )
-    res = explain_weights(booster)
+    res = explain_weights(booster, is_regression=True)
     for expl in format_as_all(res, booster):
         assert 'f12' in expl
-    res = explain_weights(booster, feature_names=feature_names)
+    res = explain_weights(booster, feature_names=feature_names, is_regression=True)
     for expl in format_as_all(res, booster):
         assert 'LSTAT' in expl
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -103,7 +103,7 @@ def test_explain_prediction_clf_binary(
         clf.fit(xs, ys)
     get_res = lambda **kwargs: explain_prediction(
         clf, 'computer graphics in space: a sign of atheism',
-        vec=vec, target_names=target_names, **kwargs, **explain_kwargs)
+        vec=vec, target_names=target_names, **dict(kwargs, **explain_kwargs))
     res = get_res()
     for expl in format_as_all(res, clf, show_feature_values=True):
         assert 'graphics' in expl

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -25,7 +25,7 @@ from .test_sklearn_explain_weights import (
     test_feature_importances_no_remaining as _check_rf_no_remaining,
 )
 from .test_sklearn_explain_prediction import (
-    assert_linear_regression_explained,
+    assert_linear_regression_explained, assert_trained_linear_regression_explained,
     test_explain_prediction_pandas as _check_explain_prediction_pandas,
 )
 
@@ -57,10 +57,7 @@ def test_explain_xgboost_regressor(boston_train):
 def test_explain_xgboost_booster(boston_train):
     xs, ys, feature_names = boston_train
     booster = xgboost.train(
-        params={
-            'objective': 'reg:linear',
-            'silent': True,
-        },
+        params={'objective': 'reg:linear', 'silent': True},
         dtrain=xgboost.DMatrix(xs, label=ys),
     )
     res = explain_weights(booster)
@@ -184,6 +181,18 @@ def test_explain_prediction_clf_interval():
 def test_explain_prediction_reg(boston_train):
     assert_linear_regression_explained(
         boston_train, XGBRegressor(), explain_prediction,
+        reg_has_intercept=True)
+
+
+def test_explain_prediction_reg_booster(boston_train):
+    X, y, feature_names = boston_train
+    booster = xgboost.train(
+        params={'objective': 'reg:linear', 'silent': True},
+        dtrain=xgboost.DMatrix(X, label=y),
+    )
+    dtest = xgboost.DMatrix(X[:1])
+    assert_trained_linear_regression_explained(
+        dtest, feature_names, booster, explain_prediction,
         reg_has_intercept=True)
 
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -23,6 +23,7 @@ from .test_sklearn_explain_weights import (
     test_explain_tree_classifier as _check_rf_classifier,
     test_explain_random_forest_and_tree_feature_filter as _check_rf_feature_filter,
     test_feature_importances_no_remaining as _check_rf_no_remaining,
+    assert_tree_classifier_explained,
 )
 from .test_sklearn_explain_prediction import (
     assert_linear_regression_explained, assert_trained_linear_regression_explained,
@@ -32,6 +33,19 @@ from .test_sklearn_explain_prediction import (
 
 def test_explain_xgboost(newsgroups_train):
     _check_rf_classifier(newsgroups_train, XGBClassifier(n_estimators=10))
+
+
+def test_explain_booster(newsgroups_train):
+    docs, y, target_names = newsgroups_train
+    vec = CountVectorizer()
+    X = vec.fit_transform(docs)
+    booster = xgboost.train(
+        params={'objective': 'multi:softprob', 'silent': True, 'max_depth': 3,
+                'num_class': len(target_names)},
+        dtrain=xgboost.DMatrix(X, label=y, missing=np.nan),
+        num_boost_round=10)
+    assert_tree_classifier_explained(booster, vec, target_names,
+                                     is_regression=False)
 
 
 def test_explain_xgboost_feature_filter(newsgroups_train):

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -190,10 +190,9 @@ def test_explain_prediction_reg_booster(boston_train):
         params={'objective': 'reg:linear', 'silent': True},
         dtrain=xgboost.DMatrix(X, label=y),
     )
-    dtest = xgboost.DMatrix(X[:1])
     assert_trained_linear_regression_explained(
-        dtest, feature_names, booster, explain_prediction,
-        reg_has_intercept=True)
+        X[0], feature_names, booster, explain_prediction,
+        reg_has_intercept=True, is_regression=True)
 
 
 def test_explain_prediction_feature_union_dense():


### PR DESCRIPTION
Support explain prediction and weights. Fixes #193 

Since the booster does not allow querying parameters that it was trained with (https://github.com/dmlc/xgboost/issues/584), I had two add one required (if booster is passed) argument ``is_regression`` for both ``explain_weights`` and ``explain_prediction``. I also added an optional ``missing`` argument for  ``explain_prediction`` with ``np.nan`` default.