### PR TITLE
libsvm-based sklearn estimators

### DIFF
--- a/docs/source/libraries/sklearn.rst
+++ b/docs/source/libraries/sklearn.rst
@@ -79,6 +79,7 @@ Linear SVMs from ``sklearn.svm`` are also supported:
 * SVR_ (only with ``kernel='linear'``)
 * NuSVC_ (only with ``kernel='linear'``, only for binary classification)
 * NuSVR_ (only with ``kernel='linear'``)
+* OneClassSVM_ (only with ``kernel='linear'``)
 
 For linear scikit-learn classifiers :func:`eli5.explain_weights` supports
 one more keyword argument, in addition to common argument and extra arguments
@@ -130,6 +131,7 @@ for all scikit-learn estimators:
 .. _SVR: http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR
 .. _NuSVC: http://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVC.html#sklearn.svm.NuSVC
 .. _NuSVR: http://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVR.html#sklearn.svm.NuSVR
+.. _OneClassSVM: http://scikit-learn.org/stable/modules/generated/sklearn.svm.OneClassSVM.html#sklearn.svm.OneClassSVM
 
 Decision Trees, Ensembles
 -------------------------

--- a/docs/source/libraries/sklearn.rst
+++ b/docs/source/libraries/sklearn.rst
@@ -75,6 +75,10 @@ Linear SVMs from ``sklearn.svm`` are also supported:
 
 * LinearSVC_
 * LinearSVR_
+* SVC_ (only with ``kernel='linear'``, only for binary classification)
+* SVR_ (only with ``kernel='linear'``)
+* NuSVC_ (only with ``kernel='linear'``, only for binary classification)
+* NuSVR_ (only with ``kernel='linear'``)
 
 For linear scikit-learn classifiers :func:`eli5.explain_weights` supports
 one more keyword argument, in addition to common argument and extra arguments
@@ -122,7 +126,10 @@ for all scikit-learn estimators:
 .. _TheilSenRegressor: http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.TheilSenRegressor.html#sklearn.linear_model.TheilSenRegressor
 .. _LinearSVC: http://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVC.html#sklearn.svm.LinearSVC
 .. _LinearSVR: http://scikit-learn.org/stable/modules/generated/sklearn.svm.LinearSVR.html#sklearn.svm.LinearSVR
-
+.. _SVC: http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC
+.. _SVR: http://scikit-learn.org/stable/modules/generated/sklearn.svm.SVR.html#sklearn.svm.SVR
+.. _NuSVC: http://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVC.html#sklearn.svm.NuSVC
+.. _NuSVR: http://scikit-learn.org/stable/modules/generated/sklearn.svm.NuSVR.html#sklearn.svm.NuSVR
 
 Decision Trees, Ensembles
 -------------------------

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -35,7 +35,12 @@ from sklearn.linear_model import (  # type: ignore
     SGDRegressor,
     TheilSenRegressor,
 )
-from sklearn.svm import LinearSVC, LinearSVR  # type: ignore
+from sklearn.svm import (  # type: ignore
+    LinearSVC,
+    LinearSVR,
+    SVR,
+    NuSVR,
+)
 from sklearn.multiclass import OneVsRestClassifier  # type: ignore
 from sklearn.tree import (   # type: ignore
     DecisionTreeClassifier,
@@ -215,6 +220,8 @@ def explain_prediction_linear_classifier(clf, doc,
 @register(RidgeCV)
 @register(SGDRegressor)
 @register(TheilSenRegressor)
+@register(SVR)
+@register(NuSVR)
 def explain_prediction_linear_regressor(reg, doc,
                                         vec=None,
                                         top=None,
@@ -242,6 +249,9 @@ def explain_prediction_linear_regressor(reg, doc,
     regressor ``reg``. Set it to True if you're passing ``vec``,
     but ``doc`` is already vectorized.
     """
+    if isinstance(reg, (SVR, NuSVR)) and reg.kernel != 'linear':
+        return explain_prediction_sklearn_not_supported(reg, doc)
+
     vec, feature_names = handle_vec(reg, doc, vec, vectorized, feature_names)
     X = get_X(doc, vec=vec, vectorized=vectorized, to_dense=True)
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -38,7 +38,9 @@ from sklearn.linear_model import (  # type: ignore
 from sklearn.svm import (  # type: ignore
     LinearSVC,
     LinearSVR,
+    SVC,
     SVR,
+    NuSVC,
     NuSVR,
 )
 from sklearn.multiclass import OneVsRestClassifier  # type: ignore
@@ -204,6 +206,23 @@ def explain_prediction_linear_classifier(clf, doc,
         res.targets.append(target_expl)
 
     return res
+
+
+@register(NuSVC)
+@register(SVC)
+def test_explain_prediction_libsvm_linear(clf, doc, *args, **kwargs):
+    if clf.kernel != 'linear':
+        return Explanation(
+            estimator=repr(clf),
+            error="only kernel='linear' is currently supported for "
+                  "libsvm-based classifiers",
+        )
+    if len(clf.classes_) > 2:
+        return Explanation(
+            estimator=repr(clf),
+            error="only binary libsvm-based classifiers are supported",
+        )
+    return explain_prediction_linear_classifier(clf, doc, *args, **kwargs)
 
 
 @register(ElasticNet)

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -42,6 +42,7 @@ from sklearn.svm import (  # type: ignore
     SVR,
     NuSVC,
     NuSVR,
+    OneClassSVM,
 )
 from sklearn.multiclass import OneVsRestClassifier  # type: ignore
 from sklearn.tree import (   # type: ignore
@@ -182,7 +183,8 @@ def explain_prediction_linear_classifier(clf, doc,
     )
 
     _weights = _linear_weights(clf, x, top, feature_names, flt_indices)
-    display_names = get_target_display_names(clf.classes_, target_names,
+    classes = getattr(clf, "classes_", ["-1", "1"])  # OneClassSVM support
+    display_names = get_target_display_names(classes, target_names,
                                              targets, top_targets, score)
 
     if is_multiclass_classifier(clf):
@@ -210,6 +212,7 @@ def explain_prediction_linear_classifier(clf, doc,
 
 @register(NuSVC)
 @register(SVC)
+@register(OneClassSVM)
 def test_explain_prediction_libsvm_linear(clf, doc, *args, **kwargs):
     if clf.kernel != 'linear':
         return Explanation(
@@ -217,7 +220,7 @@ def test_explain_prediction_libsvm_linear(clf, doc, *args, **kwargs):
             error="only kernel='linear' is currently supported for "
                   "libsvm-based classifiers",
         )
-    if len(clf.classes_) > 2:
+    if len(getattr(clf, 'classes_', [])) > 2:
         return Explanation(
             estimator=repr(clf),
             error="only binary libsvm-based classifiers are supported",

--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -153,13 +153,13 @@ def get_coef(clf, label_id, scale=None):
     """
     if len(clf.coef_.shape) == 2:
         # Most classifiers (even in binary case) and regressors
-        coef = clf.coef_[label_id]
+        coef = _dense_1d(clf.coef_[label_id])
     elif len(clf.coef_.shape) == 1:
         # SGDRegressor stores coefficients in a 1D array
         if label_id != 0:
             raise ValueError(
                 'Unexpected label_id %s for 1D coefficient' % label_id)
-        coef = clf.coef_
+        coef = _dense_1d(clf.coef_)
     elif len(clf.coef_.shape) == 0:
         # Lasso with one feature: 0D array
         coef = np.array([clf.coef_])
@@ -183,6 +183,12 @@ def get_coef(clf, label_id, scale=None):
     else:
         bias = clf.intercept_[label_id]
     return np.hstack([coef, bias])
+
+
+def _dense_1d(arr):
+    if not sp.issparse(arr):
+        return arr
+    return arr.toarray().reshape(-1)
 
 
 def get_num_features(estimator):

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -301,8 +301,8 @@ def test_explain_linear_binary(newsgroups_train_binary, clf):
 
 
 @pytest.mark.parametrize(['clf'], [
-    [SVR()],
-    [NuSVR()],
+    [SVC()],
+    [NuSVC()],
 ])
 def test_explain_linear_classifiers_unsupported_kernels(clf, newsgroups_train_binary):
     docs, y, target_names = newsgroups_train_binary

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -43,7 +43,12 @@ from sklearn.linear_model import (
     SGDRegressor,
     TheilSenRegressor,
 )
-from sklearn.svm import LinearSVC, LinearSVR
+from sklearn.svm import (
+    LinearSVC,
+    LinearSVR,
+    SVR,
+    NuSVR,
+)
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
@@ -281,9 +286,22 @@ def test_explain_linear(newsgroups_train, clf):
     [RidgeCV()],
     [SGDRegressor(random_state=42)],
     [TheilSenRegressor()],
+    [SVR(kernel='linear')],
+    [NuSVR(kernel='linear')],
 ])
 def test_explain_linear_regression(boston_train, reg):
     assert_linear_regression_explained(boston_train, reg, explain_prediction)
+
+
+@pytest.mark.parametrize(['reg'], [
+    [SVR()],
+    [NuSVR()],
+])
+def test_explain_linear_unsupported_kernels(reg, boston_train):
+    X, y, feature_names = boston_train
+    reg.fit(X, y)
+    res = explain_prediction(reg, X[0], feature_names=feature_names)
+    assert 'supported' in res.error
 
 
 @pytest.mark.parametrize(['reg'], [

--- a/tests/test_sklearn_explain_weights.py
+++ b/tests/test_sklearn_explain_weights.py
@@ -185,6 +185,29 @@ def test_explain_linear_binary(newsgroups_train_binary, clf):
 
 
 @pytest.mark.parametrize(['clf'], [
+    [SVC()],
+    [NuSVC()],
+    [SVR()],
+    [NuSVR()],
+])
+def test_explain_linear_unsupported_kernels(clf):
+    res = explain_weights(clf)
+    assert 'supported' in res.error
+
+
+@pytest.mark.parametrize(['clf'], [
+    [SVC(kernel='linear')],
+    [NuSVC(kernel='linear')],
+])
+def test_explain_linear_unsupported_multiclass(clf, newsgroups_train):
+    docs, y, target_names = newsgroups_train
+    vec = TfidfVectorizer()
+    clf.fit(vec.fit_transform(docs), y)
+    expl = explain_weights(clf, vec=vec)
+    assert 'supported' in expl.error
+
+
+@pytest.mark.parametrize(['clf'], [
     [OneVsRestClassifier(SGDClassifier(random_state=42))],
     [OneVsRestClassifier(LogisticRegression(random_state=42))],
 ])


### PR DESCRIPTION
Fixes #218

Only binary SVC and NuSVC support is implemented (see https://github.com/scikit-learn/scikit-learn/issues/9196).

TODO:

* [x] explain_weights for SVC and NuSVC 
* [x] explain_prediction for SVC and NuSVC 
* [x] explain_weights for SVR and NuSVR
* [x] explain_prediction for SVR and NuSVR 
* [x] explain_weights for OneClassSVM
* [x] explain_prediction for OneClassSVM