### PR TITLE
show predicted class in explain_prediction for binary classification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 TBA
 ---
 
+* :func:`eli5.explain_prediction` now shows predicted class for binary
+  classifiers (previously it was always showing positive class);
+* :func:`eli5.explain_prediction` supports ``targets=[<class>]`` now
+  for binary classifiers; e.g. to show result as seen for negative class,
+  you can use ``eli5.explain_prediction(..., targets=[False])``;
 * support :func:`eli5.explain_prediction` and :func:`eli5.explain_weights`
   for libsvm-based linear estimators from sklearn.svm: ``SVC(kernel='linear')``
   (only binary classification), ``NuSVC(kernel='linear')`` (only

--- a/eli5/_decision_path.py
+++ b/eli5/_decision_path.py
@@ -5,7 +5,10 @@
 from eli5._feature_weights import get_top_features_filtered
 from eli5.base import Explanation, TargetExplanation
 from eli5.sklearn.text import add_weighted_spans
-from eli5.utils import get_target_display_names
+from eli5.utils import (
+    get_target_display_names,
+    get_binary_target_scale_label_id
+)
 
 DECISION_PATHS_DESCRIPTION = """
 Feature weights are calculated by following decision paths in trees
@@ -91,19 +94,10 @@ def get_decision_path_explanation(estimator, doc, vec, vectorized,
     else:
         score, all_feature_weights = get_score_weights(0)
         if is_regression:
-            target = display_names[-1][1]
-            label_id = 1
-            scale = 1
+            target, scale, label_id = display_names[-1][1], 1.0, 1
         else:
-            label_id = 1 if score >= 0 else 0
-            scale = -1 if label_id == 0 else 1
-
-            if len(display_names) == 1:  # target is passed explicitly
-                predicted_label_id = label_id
-                label_id, target = display_names[0]
-                scale *= -1 if label_id != predicted_label_id else 1
-            else:
-                target = display_names[label_id][1]
+            target, scale, label_id = get_binary_target_scale_label_id(
+                score, display_names, proba)
 
         target_expl = TargetExplanation(
             target=target,
@@ -115,3 +109,4 @@ def get_decision_path_explanation(estimator, doc, vec, vectorized,
         explanation.targets.append(target_expl)
 
     return explanation
+

--- a/eli5/_feature_weights.py
+++ b/eli5/_feature_weights.py
@@ -51,6 +51,16 @@ def get_top_features(feature_names, coef, top, x=None):
     )
 
 
+def get_top_features_filtered(x, flt_feature_names, flt_indices,
+                              weights, top, scale=1.0):
+    if flt_indices is not None:
+        _x = mask(x, flt_indices)
+        weights = mask(weights, flt_indices)
+    else:
+        _x = x
+    return get_top_features(flt_feature_names, weights * scale, top, _x)
+
+
 def _get_top_abs_features(feature_names, coef, k, x):
     indices = argsort_k_largest_positive(np.abs(coef), k)
     features = _features(indices, feature_names, coef, x)

--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -132,6 +132,12 @@ def explain_prediction(estimator, doc, **kwargs):
         an estimator or names defined in ``target_names`` parameter.
         Must not be given with ``top_targets`` argument.
 
+        In case of binary classification you can use this argument to
+        set the class which probability or score should be displayed, with
+        an appropriate explanation. By default a result for predicted class
+        is shown. For example, you can use ``targets=[True]`` to always show
+        result for a positive class, even if the predicted label is False.
+
         This argument may be supported or not, depending on estimator type.
 
     feature_names : list, optional

--- a/eli5/ipython.py
+++ b/eli5/ipython.py
@@ -174,6 +174,12 @@ def show_prediction(estimator, doc, **kwargs):
         of class / target names which match either names provided by
         an estimator or names defined in ``target_names`` parameter.
 
+        In case of binary classification you can use this argument to
+        set the class which probability or score should be displayed, with
+        an appropriate explanation. By default a result for predicted class
+        is shown. For example, you can use ``targets=[True]`` to always show
+        result for a positive class, even if the predicted label is False.
+
         This argument may be supported or not, depending on estimator type.
 
     feature_names : list, optional

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -198,11 +198,15 @@ def explain_prediction_linear_classifier(clf, doc,
             add_weighted_spans(doc, vec, vectorized, target_expl)
             res.targets.append(target_expl)
     else:
-        label_id = 1 if score > 0 else 0
+        if len(display_names) == 1:  # target is passed explicitly
+            label_id, target = display_names[0]
+        else:
+            label_id = 1 if score >= 0 else 0
+            target = display_names[label_id][1]
         scale = -1 if label_id == 0 else 1
 
         target_expl = TargetExplanation(
-            target=display_names[label_id][1],
+            target=target,
             feature_weights=_weights(0, scale=scale),
             score=score,
             proba=proba[label_id] if proba is not None else None,

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -446,7 +446,9 @@ def explain_prediction_tree_classifier(
             label_id = 1 if score >= 0 else 0
             scale = -1 if label_id == 0 else 1
         else:
-            # Only probability is available.
+            # Only probability is available - this is the case for
+            # DecisionTreeClassifier. As contributions sum to the probability
+            # (not to the score), they shouldn't be inverted.
             label_id = 1 if proba[1] >= 0.5 else 0
             scale = 1
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -452,7 +452,7 @@ def explain_prediction_tree_classifier(
         if len(display_names) == 1:  # target is passed explicitly
             predicted_label_id = label_id
             label_id, target = display_names[0]
-            scale = -1 if label_id != predicted_label_id else 1
+            scale *= -1 if label_id != predicted_label_id else 1
         else:
             target = display_names[label_id][1]
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -411,13 +411,13 @@ def explain_prediction_tree_classifier(
     feature_names, flt_indices = feature_names.handle_filter(
         feature_filter, feature_re, x)
 
-    def _weights(label_id):
+    def _weights(label_id, scale=1.0):
         scores = feature_weights[:, label_id]
         _x = x
         if flt_indices is not None:
             scores = scores[flt_indices]
             _x = mask(_x, flt_indices)
-        return get_top_features(feature_names, scores, top, _x)
+        return get_top_features(feature_names, scores * scale, top, _x)
 
     res = Explanation(
         estimator=repr(clf),
@@ -442,11 +442,26 @@ def explain_prediction_tree_classifier(
             add_weighted_spans(doc, vec, vectorized, target_expl)
             res.targets.append(target_expl)
     else:
+        if score is not None:
+            label_id = 1 if score >= 0 else 0
+            scale = -1 if label_id == 0 else 1
+        else:
+            # Only probability is available.
+            label_id = 1 if proba[1] >= 0.5 else 0
+            scale = 1
+
+        if len(display_names) == 1:  # target is passed explicitly
+            predicted_label_id = label_id
+            label_id, target = display_names[0]
+            scale = -1 if label_id != predicted_label_id else 1
+        else:
+            target = display_names[label_id][1]
+
         target_expl = TargetExplanation(
-            target=display_names[1][1],
-            feature_weights=_weights(1),
+            target=target,
+            feature_weights=_weights(label_id, scale=scale),
             score=score if score is not None else None,
-            proba=proba[1] if proba is not None else None,
+            proba=proba[label_id] if proba is not None else None,
         )
         add_weighted_spans(doc, vec, vectorized, target_expl)
         res.targets.append(target_expl)
@@ -598,8 +613,10 @@ def _update_tree_feature_weights(X, feature_names, clf, feature_weights):
     feature_weights[feature_names.bias_idx] += norm(tree_value[0])
     for parent_idx, child_idx in zip(indices, indices[1:]):
         assert tree_feature[parent_idx] >= 0
-        feature_weights[tree_feature[parent_idx]] += (
-            norm(tree_value[child_idx]) - norm(tree_value[parent_idx]))
+        feature_idx = tree_feature[parent_idx]
+        diff = norm(tree_value[child_idx]) - norm(tree_value[parent_idx])
+        feature_weights[feature_idx] += diff
+
 
 
 def _multiply(X, coef):

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -198,11 +198,14 @@ def explain_prediction_linear_classifier(clf, doc,
             add_weighted_spans(doc, vec, vectorized, target_expl)
             res.targets.append(target_expl)
     else:
+        label_id = 1 if score > 0 else 0
+        scale = -1 if label_id == 0 else 1
+
         target_expl = TargetExplanation(
-            target=display_names[1][1],
-            feature_weights=_weights(0),
+            target=display_names[label_id][1],
+            feature_weights=_weights(0, scale=scale),
             score=score,
-            proba=proba[1] if proba is not None else None,
+            proba=proba[label_id] if proba is not None else None,
         )
         add_weighted_spans(doc, vec, vectorized, target_expl)
         res.targets.append(target_expl)
@@ -606,8 +609,8 @@ def _multiply(X, coef):
 def _linear_weights(clf, x, top, feature_names, flt_indices):
     """ Return top weights getter for label_id.
     """
-    def _weights(label_id):
-        coef = get_coef(clf, label_id)
+    def _weights(label_id, scale=1.0):
+        coef = get_coef(clf, label_id) * scale
         _x = x
         scores = _multiply(_x, coef)
         if flt_indices is not None:

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -614,11 +614,11 @@ def _linear_weights(clf, x, top, feature_names, flt_indices):
     """ Return top weights getter for label_id.
     """
     def _weights(label_id, scale=1.0):
-        coef = get_coef(clf, label_id) * scale
+        coef = get_coef(clf, label_id)
         _x = x
         scores = _multiply(_x, coef)
         if flt_indices is not None:
             scores = scores[flt_indices]
             _x = mask(_x, flt_indices)
-        return get_top_features(feature_names, scores, top, _x)
+        return get_top_features(feature_names, scores * scale, top, _x)
     return _weights

--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -104,6 +104,12 @@ def get_target_display_names(original_names=None, target_names=None,
     >>> get_target_display_names([0, 2], target_names=['foo', 'bar'], targets=[2])
     [(1, 'bar')]
 
+    >>> get_target_display_names([False, True], targets=[True])
+    [(1, True)]
+
+    >>> get_target_display_names([False, True], targets=[False])
+    [(0, False)]
+
     target_names can be a dictionary with {old_name: new_name} labels:
     >>> get_target_display_names(['x', 'y'], targets=['y', 'x'],
     ...                   target_names={'x': 'X'})

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -43,7 +43,7 @@ def test_show_prediction():
     html = eli5.show_prediction(clf, doc)
     write_html(clf, html.data, '')
     assert isinstance(html, HTML)
-    assert 'y=b' in html.data
+    assert 'y=a' in html.data
     assert 'BIAS' in html.data
     assert 'x1' in html.data
 
@@ -56,6 +56,14 @@ def test_show_prediction():
     # format_as_html arguments are supported
     html = eli5.show_prediction(clf, doc, show=['method'])
     write_html(clf, html.data, '')
-    assert 'y=b' not in html.data
+    assert 'y=a' not in html.data
     assert 'BIAS' not in html.data
     assert 'Explained as' in html.data
+
+    # top target is used
+    html = eli5.show_prediction(clf, np.array([1, 1]))
+    write_html(clf, html.data, '')
+    assert 'y=b' in html.data
+    assert 'BIAS' in html.data
+    assert 'x1' in html.data
+

--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -19,6 +19,7 @@ from .test_sklearn_explain_weights import (
 from .test_sklearn_explain_prediction import (
     assert_linear_regression_explained,
     test_explain_prediction_pandas as _check_explain_prediction_pandas,
+    test_explain_clf_binary_iris as _check_binary_classifier,
 )
 from .utils import format_as_all, check_targets_scores, get_all_features
 
@@ -73,6 +74,12 @@ def test_explain_prediction_clf_binary(newsgroups_train_binary_big):
     flt_pos_features = get_all_features(flt_res.targets[0].feature_weights.pos)
     assert 'graphics' in flt_pos_features
     assert 'computer' not in flt_pos_features
+
+
+def test_explain_prediction_clf_binary_iris(iris_train_binary):
+    clf = LGBMClassifier(n_estimators=100, max_depth=2,
+                         min_child_samples=1, min_child_weight=1)
+    _check_binary_classifier(clf, iris_train_binary)
 
 
 def test_explain_prediction_clf_multitarget(newsgroups_train):

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import pytest
 pytest.importorskip('lightning')
 
-from lightning import regression
+from lightning import regression, classification
 from lightning.impl.base import BaseEstimator
 from sklearn.multiclass import OneVsRestClassifier
 
@@ -24,8 +24,17 @@ from .test_sklearn_explain_weights import (
     assert_explained_weights_linear_regressor,
 )
 
+_DEFAULTS = {
+    classification.AdaGradClassifier: dict(alpha=1e-9, random_state=42),
+    classification.SDCAClassifier: dict(alpha=1e-9, random_state=42),
+    regression.SGDRegressor: dict(max_iter=10, alpha=1e5, random_state=42)
+}
 
-@pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
+def _instances(classes):
+    return [[cls(**_DEFAULTS.get(cls, {}))] for cls in classes]
+
+
+@pytest.mark.parametrize(['clf'], _instances(_CLASSIFIERS))
 def test_explain_predition_classifiers(newsgroups_train, clf):
     clf = OneVsRestClassifier(clf)
     assert_multiclass_linear_classifier_explained(newsgroups_train, clf,
@@ -35,13 +44,13 @@ def test_explain_predition_classifiers(newsgroups_train, clf):
                                                       explain_prediction_lightning)
 
 
-@pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
+@pytest.mark.parametrize(['clf'], _instances(_CLASSIFIERS))
 def test_explain_predition_classifiers_binary(newsgroups_train_binary, clf):
     assert_binary_linear_classifier_explained(newsgroups_train_binary, clf,
                                               explain_prediction)
 
 
-@pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
+@pytest.mark.parametrize(['clf'], _instances(_CLASSIFIERS))
 def test_explain_weights_classifiers(newsgroups_train, clf):
     clf = OneVsRestClassifier(clf)
     assert_explained_weights_linear_classifier(newsgroups_train, clf,
@@ -52,25 +61,19 @@ def test_explain_weights_classifiers(newsgroups_train, clf):
             explain_weights=explain_weights_lightning)
 
 
-regressors = [r for r in _REGRESSORS if r is not regression.SGDRegressor]
-regressor_params = (
-    [[reg()] for reg in regressors] +
-    [[regression.SGDRegressor(max_iter=10, alpha=1e5, random_state=42)]]
-)
-
-@pytest.mark.parametrize(['reg'], regressor_params)
+@pytest.mark.parametrize(['reg'], _instances(_REGRESSORS))
 def test_explain_prediction_regressors(boston_train, reg):
     assert_linear_regression_explained(boston_train, reg, explain_prediction,
                                        atol=1e-3)
 
 
-@pytest.mark.parametrize(['reg'], regressor_params)
+@pytest.mark.parametrize(['reg'], _instances(_REGRESSORS))
 def test_explain_weights_regressors(boston_train, reg):
     assert_explained_weights_linear_regressor(boston_train, reg,
                                               has_bias=False)
 
 
-@pytest.mark.parametrize(['reg'], regressor_params[:2])
+@pytest.mark.parametrize(['reg'], _instances(_REGRESSORS)[:2])
 def test_explain_prediction_pandas(reg, boston_train):
     _check_explain_prediction_pandas(reg, boston_train)
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -16,6 +16,7 @@ from eli5 import (
 from .test_sklearn_explain_prediction import (
     assert_multiclass_linear_classifier_explained,
     assert_linear_regression_explained,
+    assert_binary_linear_classifier_explained,
     test_explain_prediction_pandas as _check_explain_prediction_pandas,
 )
 from .test_sklearn_explain_weights import (
@@ -32,6 +33,12 @@ def test_explain_predition_classifiers(newsgroups_train, clf):
     if _CLASSIFIERS.index(type(clf.estimator)) == 0:
         assert_multiclass_linear_classifier_explained(newsgroups_train, clf,
                                                       explain_prediction_lightning)
+
+
+@pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])
+def test_explain_predition_classifiers_binary(newsgroups_train_binary, clf):
+    assert_binary_linear_classifier_explained(newsgroups_train_binary, clf,
+                                              explain_prediction)
 
 
 @pytest.mark.parametrize(['clf'], [[clf()] for clf in _CLASSIFIERS])

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -134,7 +134,7 @@ def assert_binary_linear_classifier_explained(newsgroups_train_binary, clf,
                              target_names=target_names, top=20)
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:
-        assert 'software' in expl
+        assert 'software' in expl or 'thanks' in expl
         assert target_names[1] in expl
 
     assert y[15] == 0

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -244,7 +244,7 @@ def assert_feature_values_present(expl, feature_names, x):
     assert any_features
 
 
-def assert_tree_explain_prediction_single_target(clf, X, feature_names):
+def assert_explain_prediction_single_target(clf, X, feature_names):
     get_res = lambda _x, **kwargs: explain_prediction(
         clf, _x, feature_names=feature_names, **kwargs)
     res = get_res(X[0])
@@ -436,11 +436,16 @@ def test_explain_tree_clf_multiclass(clf, iris_train):
     [ExtraTreesClassifier(random_state=42)],
     [GradientBoostingClassifier(learning_rate=0.075, random_state=42)],
     [RandomForestClassifier(random_state=42)],
+    [LogisticRegression(random_state=42)],
+    [OneVsRestClassifier(LogisticRegression(random_state=42))],
+    [SGDClassifier(random_state=42)],
+    [SVC(kernel='linear', random_state=42)],
+    [NuSVC(kernel='linear', random_state=42)],
 ])
-def test_explain_tree_clf_binary(clf, iris_train_binary):
+def test_explain_clf_binary_iris(clf, iris_train_binary):
     X, y, feature_names = iris_train_binary
     clf.fit(X, y)
-    assert_tree_explain_prediction_single_target(clf, X, feature_names)
+    assert_explain_prediction_single_target(clf, X, feature_names)
 
 
 @pytest.mark.parametrize(['reg'], [
@@ -473,7 +478,7 @@ def test_explain_tree_regressor_multitarget(reg):
 def test_explain_tree_regressor(reg, boston_train):
     X, y, feature_names = boston_train
     reg.fit(X, y)
-    assert_tree_explain_prediction_single_target(reg, X, feature_names)
+    assert_explain_prediction_single_target(reg, X, feature_names)
 
 
 @pytest.mark.parametrize(['clf'], [

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from functools import partial
 from pprint import pprint
 import re
+from typing import List
 
 import pytest
 import numpy as np
@@ -57,6 +58,7 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from eli5 import explain_prediction, explain_prediction_sklearn
+from eli5.base import Explanation
 from eli5.formatters import format_as_text, fields
 from eli5.sklearn.utils import has_intercept
 from .utils import (
@@ -146,6 +148,8 @@ def assert_binary_linear_classifier_explained(newsgroups_train_binary, clf,
         assert 'god' in expl
         assert target_names[0] in expl
 
+    assert_correct_class_explained_binary(clf, X[::10])
+
 
 def assert_linear_regression_explained(boston_train, reg, explain_prediction,
                                        atol=1e-8, reg_has_intercept=None):
@@ -234,6 +238,47 @@ def assert_multitarget_linear_regression_explained(reg, explain_prediction):
     assert len(top_targets_res.targets) == 1
 
 
+def assert_correct_class_explained_binary(clf, X):
+    size = X.shape[0]
+    expl_predicted = assert_predicted_class_used(clf, X)
+    expl_target0 = assert_class_used(clf, X, np.zeros(size), targets=[0])
+    expl_target1 = assert_class_used(clf, X, np.ones(size), targets=[1])
+
+    get_fw = lambda expl: expl.targets[0].feature_weights
+    for pred, t0, t1 in zip(expl_predicted, expl_target0, expl_target1):
+        # sanity check
+        assert get_fw(pred).pos == get_fw(pred).pos
+
+        # explanation for the predicted class should be the same as either
+        # positive or negative class explanation
+        assert get_fw(pred).pos == get_fw(t0).pos or get_fw(pred).pos == get_fw(t1).pos
+        assert get_fw(pred).neg == get_fw(t0).neg or get_fw(pred).neg == get_fw(t1).neg
+
+        # explanations shouldn't be the same for positive and negative classes
+        assert get_fw(t0).pos != get_fw(t1).pos
+        assert get_fw(t0).neg != get_fw(t1).neg
+
+
+def assert_predicted_class_used(clf, X):
+    """ Check that predicted classes are used for explanations
+    of X predictions """
+    y_pred = clf.predict(X)
+    return assert_class_used(clf, X, y_pred)
+
+
+def assert_class_used(clf, X, y, **explain_kwargs):
+    # type: (...) -> List[Explanation]
+    """ Check that classes y are used for explanations of X predictions """
+    explanations = []
+    for x, pred_target in zip(X, y):
+        res = explain_prediction(clf, x, **explain_kwargs)  # type: Explanation
+        explanations.append(res)
+        assert len(res.targets) == 1
+        if res.targets[0].score != 0:
+            assert res.targets[0].target == pred_target
+    return explanations
+
+
 def assert_feature_values_present(expl, feature_names, x):
     assert 'Value' in expl
     any_features = False
@@ -244,13 +289,17 @@ def assert_feature_values_present(expl, feature_names, x):
     assert any_features
 
 
-def assert_explain_prediction_single_target(clf, X, feature_names):
+def assert_explain_prediction_single_target(estimator, X, feature_names):
     get_res = lambda _x, **kwargs: explain_prediction(
-        clf, _x, feature_names=feature_names, **kwargs)
+        estimator, _x, feature_names=feature_names, **kwargs)
     res = get_res(X[0])
-    for expl in format_as_all(res, clf):
+    for expl in format_as_all(res, estimator):
         assert_feature_values_present(expl, feature_names, X[0])
 
+    # take first elements in the dataset; check that
+    # 1. <BIAS> feature is present;
+    # 2. scores have correct absolute values;
+    # 3. feature filter function works.
     checked_flt = False
     all_expls = []
     for x in X[:5]:
@@ -260,18 +309,23 @@ def assert_explain_prediction_single_target(clf, X, feature_names):
         assert '<BIAS>' in text_expl
         check_targets_scores(res)
         all_expls.append(text_expl)
-
-        get_all = lambda fw: get_all_features(fw.pos) | get_all_features(fw.neg)
-        all_features = get_all(res.targets[0].feature_weights)
-        if len(all_features) > 1:
-            f = list(all_features - {'<BIAS>'})[0]
-            flt_res = get_res(x, feature_filter=lambda name, _: name != f)
-            flt_features = get_all(flt_res.targets[0].feature_weights)
-            assert flt_features == (all_features - {f})
-            checked_flt = True
+        checked_flt = checked_flt or _assert_feature_filter_works(get_res, x)
 
     assert checked_flt
     assert any(f in ''.join(all_expls) for f in feature_names)
+
+
+def _assert_feature_filter_works(get_res, x):
+    res = get_res(x)
+    get_all = lambda fw: get_all_features(fw.pos) | get_all_features(fw.neg)
+    all_features = get_all(res.targets[0].feature_weights)
+    if len(all_features) > 1:
+        f = list(all_features - {'<BIAS>'})[0]
+        flt_res = get_res(x, feature_filter=lambda name, _: name != f)
+        flt_features = get_all(flt_res.targets[0].feature_weights)
+        assert flt_features == (all_features - {f})
+        return True
+    return False
 
 
 @pytest.mark.parametrize(['clf'], [
@@ -389,7 +443,7 @@ def test_explain_linear_regression(boston_train, reg):
     [SVR()],
     [NuSVR()],
 ])
-def test_explain_linear_regressors_unsupported_kernels(reg, boston_train):
+def test_explain_libsvm_linear_regressors_unsupported_kernels(reg, boston_train):
     X, y, feature_names = boston_train
     reg.fit(X, y)
     res = explain_prediction(reg, X[0], feature_names=feature_names)
@@ -446,6 +500,7 @@ def test_explain_clf_binary_iris(clf, iris_train_binary):
     X, y, feature_names = iris_train_binary
     clf.fit(X, y)
     assert_explain_prediction_single_target(clf, X, feature_names)
+    assert_correct_class_explained_binary(clf, X)
 
 
 @pytest.mark.parametrize(['reg'], [

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -128,13 +128,23 @@ def assert_binary_linear_classifier_explained(newsgroups_train_binary, clf,
     X = vec.fit_transform(docs)
     clf.fit(X, y)
 
-    get_res = lambda **kwargs: explain_prediction(
-        clf, docs[2], vec=vec, target_names=target_names, top=20, **kwargs)
-    res = get_res()
-    pprint(res)
+    assert y[2] == 1
+    cg_document = docs[2]
+    res = explain_prediction(clf, cg_document, vec=vec,
+                             target_names=target_names, top=20)
     expl_text, expl_html = format_as_all(res, clf)
     for expl in [expl_text, expl_html]:
         assert 'software' in expl
+        assert target_names[1] in expl
+
+    assert y[15] == 0
+    atheism_document = docs[15]
+    res = explain_prediction(clf, atheism_document, vec=vec,
+                             target_names=target_names, top=20)
+    expl_text, expl_html = format_as_all(res, clf)
+    for expl in [expl_text, expl_html]:
+        assert 'god' in expl
+        assert target_names[0] in expl
 
 
 def assert_linear_regression_explained(boston_train, reg, explain_prediction,
@@ -288,6 +298,8 @@ def test_explain_linear(newsgroups_train, clf):
 
 @pytest.mark.parametrize(['clf'], [
     [LogisticRegression(random_state=42)],
+    [LogisticRegressionCV(random_state=42)],
+    [OneVsRestClassifier(LogisticRegression(random_state=42))],
     [SGDClassifier(random_state=42)],
     [SVC(kernel='linear', random_state=42)],
     [SVC(kernel='linear', random_state=42, decision_function_shape='ovr')],

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -248,11 +248,19 @@ def assert_correct_class_explained_binary(clf, X):
     for pred, t0, t1 in zip(expl_predicted, expl_target0, expl_target1):
         # sanity check
         assert get_fw(pred).pos == get_fw(pred).pos
+        y_pred = pred.targets[0].target
+        y_1 = t1.targets[0].target
 
-        # explanation for the predicted class should be the same as either
-        # positive or negative class explanation
-        assert get_fw(pred).pos == get_fw(t0).pos or get_fw(pred).pos == get_fw(t1).pos
-        assert get_fw(pred).neg == get_fw(t0).neg or get_fw(pred).neg == get_fw(t1).neg
+        if y_pred == y_1:
+            # targets=[True] result is the same as for the predicted class
+            # if predicted class is True
+            assert get_fw(pred).pos == get_fw(t1).pos
+            assert get_fw(pred).neg == get_fw(t1).neg
+        else:
+            # targets=[False] result is the same as for the predicted class
+            # if predicted class is False
+            assert get_fw(pred).pos == get_fw(t0).pos
+            assert get_fw(pred).neg == get_fw(t0).neg
 
         # explanations shouldn't be the same for positive and negative classes
         assert get_fw(t0).pos != get_fw(t1).pos

--- a/tests/test_sklearn_vectorizers.py
+++ b/tests/test_sklearn_vectorizers.py
@@ -18,15 +18,15 @@ from eli5.sklearn import invert_hashing_and_fit, InvertableHashingVectorizer
 from .utils import format_as_all, get_all_features, get_names_coefs, write_html
 
 
-def check_explain_linear_binary(res, clf):
+def check_explain_linear_binary(res, clf, target='alt.atheism'):
     expl_text, expl_html = format_as_all(res, clf)
     assert len(res.targets) == 1
     e = res.targets[0]
-    assert e.target == 'comp.graphics'
-    neg = get_all_features(e.feature_weights.neg)
-    assert 'objective' in neg
+    assert e.target == target
+    pos = get_all_features(e.feature_weights.pos)
+    assert 'objective' in pos
     for expl in [expl_text, expl_html]:
-        assert 'comp.graphics' in expl
+        assert target in expl
         assert 'objective' in expl
 
 
@@ -50,9 +50,9 @@ def test_explain_linear_binary(vec, newsgroups_train_binary):
         top=20, vectorized=True)
     if isinstance(vec, HashingVectorizer):
         # InvertableHashingVectorizer must be passed with vectorized=True
-        neg_weights = res_vectorized.targets[0].feature_weights.neg
-        neg_vectorized = get_all_features(neg_weights)
-        assert all(name.startswith('x') for name in neg_vectorized)
+        pos_weights = res_vectorized.targets[0].feature_weights.pos
+        pos_vectorized = get_all_features(pos_weights)
+        assert all(name.startswith('x') for name in pos_vectorized)
     else:
         assert res_vectorized == _without_weighted_spans(res)
 

--- a/tests/test_xgboost.py
+++ b/tests/test_xgboost.py
@@ -26,7 +26,10 @@ from .test_sklearn_explain_weights import (
     assert_tree_classifier_explained,
 )
 from .test_sklearn_explain_prediction import (
-    assert_linear_regression_explained, assert_trained_linear_regression_explained,
+    assert_linear_regression_explained,
+    assert_trained_linear_regression_explained,
+    assert_explain_prediction_single_target,
+    test_explain_clf_binary_iris as _check_binary_classifier,
     test_explain_prediction_pandas as _check_explain_prediction_pandas,
 )
 
@@ -125,6 +128,20 @@ def test_explain_prediction_clf_binary(
     flt_value_res = get_res(feature_filter=lambda _, v: not np.isnan(v))
     for expl in format_as_all(flt_value_res, clf, show_feature_values=True):
         assert 'Missing' not in expl
+
+@pytest.mark.parametrize(['clf'], [
+    [XGBClassifier(n_estimators=50)],
+    [XGBRegressor(n_estimators=50)],
+])
+def test_explain_prediction_xgboost_binary_iris(clf, iris_train_binary):
+    X, y, feature_names = iris_train_binary
+    clf.fit(X, y)
+    assert_explain_prediction_single_target(clf, X, feature_names)
+
+
+def test_explain_prediction_xgboost_clf_binary_iris(iris_train_binary):
+    clf = XGBClassifier(n_estimators=50)
+    _check_binary_classifier(clf, iris_train_binary)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,14 +98,15 @@ def check_targets_scores(explanation, atol=1e-8):
         weights_sum = (sum(fw.weight for fw in weights.pos) +
                        sum(fw.weight for fw in weights.neg))
         expected = target.score if target.score is not None else target.proba
-        assert np.isclose(expected, weights_sum, atol=atol), \
+        assert np.isclose(abs(expected), abs(weights_sum), atol=atol), \
             (expected, weights_sum)
     if any(t.score is not None for t in targets):
         if len(targets) == 1 and targets[0].proba is not None:
             target = targets[0]
             # one target with proba => assume sigmoid
-            assert np.isclose(target.proba, 1. / (1 + np.exp(-target.score)),
-                              atol=atol)
+            proba = 1. / (1 + np.exp(-target.score))
+            assert np.isclose(target.proba, proba, atol=atol) or \
+                   np.isclose(target.proba, 1-proba, atol=atol)
         elif any(t.proba is not None for t in targets):
             # many targets with proba => assume softmax
             norm = np.sum(np.exp([t.score for t in targets]))

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra
 deps=
     pytest
     pytest-cov
+    pytest-xdist
     hypothesis[numpy] !=3.5.1, !=3.5.0
     numpy
     scipy


### PR DESCRIPTION
Fixes #223.

TODO:

* [x] XGBoost
* [x] tests for XGBoost
* [x] LightGBM
* [x] tests for LightGBM
* [x] sklearn linear models
* [x] lightning linear models
* [x] sklearn tree-based classifiers
* [x] tests for sklearn tree-based classifiers
* [x] add support for `targets` argument in case of binary clasification
* [x] tests for `targets` in case of binary classification
* [x] update docs ~~and notebooks~~ (I'll update notebooks before the release)

I've kept `score` unscaled, so user can see e.g. "y=0: probability 0.708, score -0.883"; feature weights sum to `-1*score` in this case. I'm not sure if that's the way to go or not.