### PR TITLE
transform_feature_names for scalers

### DIFF
--- a/docs/source/libraries/sklearn.rst
+++ b/docs/source/libraries/sklearn.rst
@@ -260,8 +260,14 @@ Currently the following transformers are supported out of the box:
 * nested FeatureUnions and Pipelines;
 * SelectorMixin-based transformers: SelectPercentile_,
   SelectKBest_, GenericUnivariateSelect_, VarianceThreshold_,
-  RFE_, RFECV_, SelectFromModel_, RandomizedLogisticRegression_.
+  RFE_, RFECV_, SelectFromModel_, RandomizedLogisticRegression_;
+* scalers from sklearn.preprocessing: MinMaxScaler_, StandardScaler_,
+  MaxAbsScaler_, RobustScaler_.
 
+.. _MinMaxScaler: http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html
+.. _StandardScaler: http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html#sklearn.preprocessing.StandardScaler
+.. _MaxAbsScaler: http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MaxAbsScaler.html#sklearn.preprocessing.MaxAbsScaler
+.. _RobustScaler: http://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.RobustScaler.html#sklearn.preprocessing.RobustScaler
 .. _GenericUnivariateSelect: http://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.GenericUnivariateSelect.html
 .. _SelectPercentile: http://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.SelectPercentile.html
 .. _SelectKBest: http://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.SelectKBest.html
@@ -272,6 +278,7 @@ Currently the following transformers are supported out of the box:
 .. _RandomizedLogisticRegression: http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RandomizedLogisticRegression.html
 .. _Pipeline: http://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline
 .. _singledispatch: https://pypi.python.org/pypi/singledispatch
+
 
 .. _sklearn-unhashing:
 

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -38,8 +38,10 @@ def _select_names(est, in_names=None):
 @transform_feature_names.register(MaxAbsScaler)
 @transform_feature_names.register(RobustScaler)
 def _select_scaling(est, in_names=None):
-    return _get_feature_names(est, feature_names=in_names,
-                              num_features=est.scale_.shape[0])
+    if in_names is None:
+        in_names = _get_feature_names(est, feature_names=in_names,
+                                      num_features=est.scale_.shape[0])
+    return [name for name in in_names]
 
 
 # Pipelines

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -8,7 +8,7 @@ from sklearn.linear_model import (  # type: ignore
     RandomizedLogisticRegression,
     RandomizedLasso,
 )
-from sklearn.preprocessing import (
+from sklearn.preprocessing import (  # type: ignore
     MinMaxScaler,
     StandardScaler,
     MaxAbsScaler,

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -37,7 +37,7 @@ def _select_names(est, in_names=None):
 @transform_feature_names.register(StandardScaler)
 @transform_feature_names.register(MaxAbsScaler)
 @transform_feature_names.register(RobustScaler)
-def _select_scaling(est, in_names=None):
+def _transform_scaling(est, in_names=None):
     if in_names is None:
         in_names = _get_feature_names(est, feature_names=in_names,
                                       num_features=est.scale_.shape[0])

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -8,6 +8,12 @@ from sklearn.linear_model import (  # type: ignore
     RandomizedLogisticRegression,
     RandomizedLasso,
 )
+from sklearn.preprocessing import (
+    MinMaxScaler,
+    StandardScaler,
+    MaxAbsScaler,
+    RobustScaler,
+)
 
 from eli5.transform import transform_feature_names
 from eli5.sklearn.utils import get_feature_names as _get_feature_names
@@ -23,6 +29,17 @@ def _select_names(est, in_names=None):
     in_names = _get_feature_names(est, feature_names=in_names,
                                   num_features=len(mask))
     return [in_names[i] for i in np.flatnonzero(mask)]
+
+
+# Scaling
+
+@transform_feature_names.register(MinMaxScaler)
+@transform_feature_names.register(StandardScaler)
+@transform_feature_names.register(MaxAbsScaler)
+@transform_feature_names.register(RobustScaler)
+def _select_scaling(est, in_names=None):
+    return _get_feature_names(est, feature_names=in_names,
+                              num_features=est.scale_.shape[0])
 
 
 # Pipelines

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -20,7 +20,14 @@ from sklearn.linear_model import (
     RandomizedLogisticRegression,
     RandomizedLasso,  # TODO: add tests and document
 )
-from sklearn.pipeline import FeatureUnion
+from sklearn.preprocessing import (
+    MinMaxScaler,
+    StandardScaler,
+    MaxAbsScaler,
+    RobustScaler,
+)
+from sklearn.pipeline import FeatureUnion, make_pipeline
+
 from eli5 import transform_feature_names
 
 
@@ -41,6 +48,14 @@ def selection_score_func(X, y):
 
 @pytest.mark.parametrize('transformer,expected', [
     (MyFeatureExtractor(), ['f1', 'f2', 'f3']),
+    (make_pipeline(StandardScaler(), MyFeatureExtractor()),
+     ['f1', 'f2', 'f3']),
+    (make_pipeline(MinMaxScaler(), MyFeatureExtractor()),
+     ['f1', 'f2', 'f3']),
+    (make_pipeline(MaxAbsScaler(), MyFeatureExtractor()),
+     ['f1', 'f2', 'f3']),
+    (make_pipeline(RobustScaler(), MyFeatureExtractor()),
+     ['f1', 'f2', 'f3']),
     (SelectKBest(selection_score_func, k=1),
      ['<NAME3>']),
     (SelectKBest(selection_score_func, k=2),

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -48,6 +48,7 @@ def selection_score_func(X, y):
 
 @pytest.mark.parametrize('transformer,expected', [
     (MyFeatureExtractor(), ['f1', 'f2', 'f3']),
+
     (make_pipeline(StandardScaler(), MyFeatureExtractor()),
      ['f1', 'f2', 'f3']),
     (make_pipeline(MinMaxScaler(), MyFeatureExtractor()),
@@ -56,6 +57,11 @@ def selection_score_func(X, y):
      ['f1', 'f2', 'f3']),
     (make_pipeline(RobustScaler(), MyFeatureExtractor()),
      ['f1', 'f2', 'f3']),
+    (StandardScaler(), ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
+    (MinMaxScaler(), ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
+    (MaxAbsScaler(), ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
+    (RobustScaler(), ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
+
     (SelectKBest(selection_score_func, k=1),
      ['<NAME3>']),
     (SelectKBest(selection_score_func, k=2),


### PR DESCRIPTION
I can see 3 main ways to show feature names for scalers:

1) display feature names as-is (like it is done in https://github.com/scikit-learn/scikit-learn/pull/6431);
2) show that feature names are scaled/normalized, but hide the details, e.g. `scaled(x1)`;
3) show the complete formula, e.g. `(x1*0.312 - 1.232)` for StandardScaler

In this PR (1) is implemented; at least it is more useful than doing nothing. 

It seems we may want an optional "verbose mode" for feature names, as there are use cases you want the whole formula, and there are use cases you only care about input feature names.