### PR TITLE
Add format_* functions to top-level docs

### DIFF
--- a/docs/source/autodocs/eli5.rst
+++ b/docs/source/autodocs/eli5.rst
@@ -23,3 +23,13 @@ The following functions are exposed to a top level, e.g.
 .. autofunction:: eli5.explain_prediction_df
 
 .. autofunction:: eli5.explain_prediction_dfs
+
+.. autofunction:: eli5.format_as_text
+
+.. autofunction:: eli5.format_as_html
+
+.. autofunction:: eli5.format_as_dataframe
+
+.. autofunction:: eli5.format_as_dataframes
+
+.. autofunction:: eli5.format_as_dict


### PR DESCRIPTION
`format_as_text` goes first followed by `format_as_html` as they have similar kwargs and explanation in `format_as_text` is more detailed.

Fixes #212