### PR TITLE
Fixed compatibility with LightGBM master. Fixes GH-238.

### DIFF
--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -29,7 +29,7 @@ def lgb_clf():
     return LGBMClassifier(
         n_estimators=10,
         min_child_samples=2,
-        min_child_weight=0,
+        min_child_weight=1,
         seed=42,
     )
 

--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -26,9 +26,12 @@ from .utils import format_as_all, check_targets_scores, get_all_features
 
 @pytest.fixture()
 def lgb_clf():
-    return LGBMClassifier(n_estimators=10,
-                          min_child_samples=2,
-                          min_child_weight=0)
+    return LGBMClassifier(
+        n_estimators=10,
+        min_child_samples=2,
+        min_child_weight=0,
+        seed=42,
+    )
 
 
 @pytest.mark.parametrize(['importance_type'], [['gain'], ['split'], ['weight']])

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ basepython=python3.5
 deps=
     {[testenv]deps}
     xgboost
-    lightgbm==2.0.4
+    lightgbm != 2.0.5, != 2.0.6
 
 commands=
     pip install -e .


### PR DESCRIPTION
A fix for #238. 

In LightGBM master `leaf_parent` is removed, and constant tree no longer use splits.

2.0.5 and 2.0.6 are still not supported, as they segfault.
Currently there is no newer version on pypi, so tests only check that eli5 is still compatible with LightGBM 2.0.4, but tests pass for me locally with LightGBM master.