### PR TITLE
Fix GH-248

### DIFF
--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -356,18 +356,19 @@ def _parse_tree_dump(text_dump):
 def _parse_dump_line(line):
     # type: (str) -> Tuple[int, Dict[str, Any]]
     branch_match = re.match(
-        '^(\t*)(\d+):\[([^<]+)<([^\]]+)\] '
+        '^(\t*)(\d+):\[([^<]+)<?([^\]]*)\] '
         'yes=(\d+),no=(\d+),missing=(\d+),'
         'gain=([^,]+),cover=(.+)$', line)
     if branch_match:
         tabs, node_id, feature, condition, yes, no, missing, gain, cover = \
             branch_match.groups()
         depth = len(tabs)
+        split_condition = float(condition) if condition else 0.
         return depth, {
             'depth': depth,
             'nodeid': int(node_id),
             'split': feature,
-            'split_condition': float(condition),
+            'split_condition': split_condition,
             'yes': int(yes),
             'no': int(no),
             'missing': int(missing),


### PR DESCRIPTION
I think, this will fix #248 
Can't run tests, because in my version of xgboost `xgb.booster()` must be replaced by `xgb.get_booster()`