### PR TITLE
[WIP] Add `sample_weight` to permutation importances scikit-learn interface

### DIFF
--- a/eli5/permutation_importance.py
+++ b/eli5/permutation_importance.py
@@ -56,6 +56,7 @@ def get_score_importances(
         score_func,  # type: Callable[[Any, Any], float]
         X,
         y,
+        sample_weight=None,
         n_iter=5,  # type: int
         columns_to_shuffle=None,
         random_state=None
@@ -76,7 +77,7 @@ def get_score_importances(
     If you just want feature importances, you can take a mean of the result::
 
         import numpy as np
-        from eli5.permutation_importance import get_scores_importances
+        from eli5.permutation_importance import get_score_importances
 
         base_score, score_decreases = get_score_importances(score_func, X, y)
         feature_importances = np.mean(score_decreases, axis=0)
@@ -87,14 +88,15 @@ def get_score_importances(
     scores_decreases = []
     for i in range(n_iter):
         scores_shuffled = _get_scores_shufled(
-            score_func, X, y, columns_to_shuffle=columns_to_shuffle,
+            score_func, X, y, sample_weight,
+            columns_to_shuffle=columns_to_shuffle,
             random_state=rng
         )
         scores_decreases.append(-scores_shuffled + base_score)
     return base_score, scores_decreases
 
 
-def _get_scores_shufled(score_func, X, y, columns_to_shuffle=None,
+def _get_scores_shufled(score_func, X, y, sample_weight, columns_to_shuffle=None,
                         random_state=None):
     Xs = iter_shuffled(X, columns_to_shuffle, random_state=random_state)
-    return np.array([score_func(X_shuffled, y) for X_shuffled in Xs])
+    return np.array([score_func(X_shuffled, y, sample_weight) for X_shuffled in Xs])


### PR DESCRIPTION
Sample weights are an important parameter for imbalanced problems and some forms of bias correction and are part of the scikit-learn API for all [classifiers](https://github.com/pelucid/scikit-learn/blob/master/sklearn/base.py#L316) and [regressors](https://github.com/pelucid/scikit-learn/blob/master/sklearn/base.py#L349). They can also have a large impact on permutation importances and are not supported through `fit_params` due to the need to split them into test / train like X and y for the CV case.

Opening this as a PR now to start a discussion before I do anymore work. At the very least I would like to add to the documentation how you can use `get_score_importances` and pass sample weights through the `score_func` if you require them.

As a very quick (and perhaps slightly flawed) example, if we calculate permutation importances for our standard data and then imbalance it (the reverse of the standard case)

```
from sklearn.datasets import load_breast_cancer
from sklearn.utils import shuffle
from sklearn.svm import SVC
from eli5.sklearn import PermutationImportance
import matplotlib.pyplot as plt
import seaborn

seaborn.set()

data = load_breast_cancer()
X, y = shuffle(data.data, data.target, random_state=13)

perm = PermutationImportance(SVC(), cv=None).fit(X, y, sample_weight=None)

#But what if we had 10x more 0 labels than 1?
sample_weight = y.copy()
sample_weight[sample_weight==1] = 1
sample_weight[sample_weight==0] = 10

perm10 = PermutationImportance(SVC(), cv=None).fit(X, y, sample_weight=sample_weight)

seaborn.barplot(x=perm10.feature_importances_, y=data.feature_names, label='10x', color='b')
seaborn.barplot(x=perm.feature_importances_, y=data.feature_names, label='~balanced', color='g')
plt.legend()
```

![fig1](https://user-images.githubusercontent.com/1278326/39625531-b96367c0-4f95-11e8-9e1c-a09007955569.png)

I have seen dramatic (and less uniform) changes in feature_importances in real world imbalanced sets when doing this. I'll try and find a better example.

**Issues**
- As currently implemented this would break `PermutationImportance` if an `estimator` does not support `sample_weight` on its `fit` method.
- More of a scikit-learn issue but sample weights can get confusing fast if you combine them with a `class_weight` which some classifiers (e.g.`RandomForestClassifier`) support. In this case your sample weights are modified during the classifier fit to balance the classes but not during the permutation importance fit for the test set which can be misleading.
- Not tested