### PR TITLE
add convert_objects() to get_X

### DIFF
--- a/eli5/sklearn/utils.py
+++ b/eli5/sklearn/utils.py
@@ -226,7 +226,7 @@ def get_X(doc, vec=None, vectorized=False, to_dense=False):
             X = np.array([doc])
         elif pandas_available and isinstance(doc, pd.Series):
             # Convert to a DataFrame with a single row
-            X = doc.to_frame().transpose()
+            X = doc.to_frame().transpose().convert_objects()
         else:
             X = doc
     else:


### PR DESCRIPTION
get_X was taking a pandas Series and transposing it, but this made all the dtypes "Objects" instead of their actual dtypes. the convert_objects function appears to fix this issue.