### PR TITLE
fix leaf_ids type error

### DIFF
--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -243,7 +243,8 @@ def _prediction_feature_weights(booster, dmatrix, n_targets,
     http://blog.datadive.net/interpreting-random-forests/
     """
     # XGBClassifier does not have pred_leaf argument, so use booster
-    leaf_ids, = booster.predict(dmatrix, pred_leaf=True)
+    predictions = booster.predict(dmatrix, pred_leaf=True)
+    leaf_ids = result.reshape((len(predictions.T)))
     xgb_feature_names = {f: i for i, f in enumerate(xgb_feature_names)}
     tree_dumps = booster.get_dump(with_stats=True)
     assert len(tree_dumps) == len(leaf_ids)


### PR DESCRIPTION
fixed TypeError: object of type 'numpy.int32' has no len()
```
File "C:\Users\username\test.py", line 20, in churn_factor_xgb
    prediction_text = explain_prediction(model,X_test.iloc[i])
  File "C:\ProgramData\Anaconda3\lib\site-packages\singledispatch.py", line 210, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "C:\ProgramData\Anaconda3\lib\site-packages\eli5\xgboost.py", line 196, in explain_prediction_xgboost
    booster, dmatrix, n_targets, feature_names, xgb_feature_names)
  File "C:\ProgramData\Anaconda3\lib\site-packages\eli5\xgboost.py", line 247, in _prediction_feature_weights
    assert len(tree_dumps) == len(leaf_ids)
TypeError: object of type 'numpy.int32' has no len()
```