### PR TITLE
Prefer singledispatch from standart library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       env: TOXENV=mypy
     - python: 3.6
       env: TOXENV=docs
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOXENV=py37
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-      env: TOXENV=py37
+      env: TOXENV=py37-nodeps
 
 addons:
     apt:

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -3,9 +3,9 @@ import inspect
 import attr  # type: ignore
 
 try:
-    from functools import singledispatch
+    from functools import singledispatch  # type: ignore
 except ImportError:
-    from singledispatch import singledispatch
+    from singledispatch import singledispatch  # type: ignore
 
 
 def attrs(class_):

--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -2,6 +2,11 @@ import inspect
 
 import attr  # type: ignore
 
+try:
+    from functools import singledispatch
+except ImportError:
+    from singledispatch import singledispatch
+
 
 def attrs(class_):
     """ Like attr.s with slots=True,

--- a/eli5/explain.py
+++ b/eli5/explain.py
@@ -3,9 +3,8 @@
 Dispatch module. Explanation functions for conctere estimator classes
 are defined in submodules.
 """
-from singledispatch import singledispatch
-
 from eli5.base import Explanation
+from eli5.base_utils import singledispatch
 
 
 @singledispatch

--- a/eli5/formatters/as_dataframe.py
+++ b/eli5/formatters/as_dataframe.py
@@ -1,5 +1,4 @@
 from itertools import chain
-from singledispatch import singledispatch
 from typing import Any, Dict, List, Optional
 import warnings
 
@@ -10,6 +9,7 @@ from eli5.base import (
     Explanation, FeatureImportances, TargetExplanation,
     TransitionFeatureWeights,
 )
+from eli5.base_utils import singledispatch
 
 
 def explain_weights_df(estimator, **kwargs):

--- a/eli5/lightning.py
+++ b/eli5/lightning.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from singledispatch import singledispatch
 
 from lightning.impl.base import BaseEstimator  # type: ignore
 from lightning import classification, regression   # type: ignore
 from sklearn.multiclass import OneVsRestClassifier   # type: ignore
 
 from eli5.base import Explanation
+from eli5.base_utils import singledispatch
 from eli5.sklearn import (
     explain_linear_classifier_weights,
     explain_linear_regressor_weights,

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from singledispatch import singledispatch
 from functools import partial
 
 import numpy as np  # type: ignore
@@ -51,6 +50,7 @@ from sklearn.tree import (   # type: ignore
 )
 
 from eli5.base import Explanation, TargetExplanation
+from eli5.base_utils import singledispatch
 from eli5.utils import (
     get_target_display_names,
     get_binary_target_scale_label_id

--- a/eli5/sklearn/explain_weights.py
+++ b/eli5/sklearn/explain_weights.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from singledispatch import singledispatch
 
 import numpy as np  # type: ignore
 
@@ -57,6 +56,7 @@ from sklearn.tree import (  # type: ignore
 
 from eli5.base import (
     Explanation, TargetExplanation, FeatureImportances)
+from eli5.base_utils import singledispatch
 from eli5._feature_weights import get_top_features
 from eli5.utils import argsort_k_largest_positive, get_target_display_names
 from eli5.sklearn.unhashing import handle_hashing_vec, is_invhashing

--- a/eli5/transform.py
+++ b/eli5/transform.py
@@ -1,6 +1,6 @@
 """Handling transformation pipelines in explanations"""
 
-from singledispatch import singledispatch
+from eli5.base_utils import singledispatch
 
 
 @singledispatch

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,17 @@ setup(
         'jinja2',
         'numpy >= 1.9.0',
         'scipy',
-        'singledispatch >= 3.4.0.3',
         'six',
         'scikit-learn >= 0.18',
         'typing',
         'graphviz',
         'tabulate>=0.7.7',
     ],
+    extras_require={
+        ":python_version<'3.5.6'": [
+            'singledispatch >= 3.4.0.3',
+        ],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 ; https://github.com/Microsoft/LightGBM/tree/master/python-package#lightgbm-python-package.
 
 [tox]
-envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy,py37
+envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy,py37-nodeps
 
 [base]
 deps=
@@ -94,3 +94,13 @@ deps=
 changedir=docs/source
 commands=
     sphinx-build -W -b html . {envtmpdir}/html
+
+
+[testenv:py37-nodeps]
+deps=
+    {[base]deps}
+
+commands=
+    ; without lightning as it is optional
+    pip install -e .
+    bash _ci/runtests_nodeps.sh {posargs: eli5 tests}

--- a/tox.ini
+++ b/tox.ini
@@ -97,10 +97,5 @@ commands=
 
 
 [testenv:py37-nodeps]
-deps=
-    {[base]deps}
-
-commands=
-    ; without lightning as it is optional
-    pip install -e .
-    bash _ci/runtests_nodeps.sh {posargs: eli5 tests}
+deps={[base]deps}
+commands={[testenv:py35-nodeps]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 ; https://github.com/Microsoft/LightGBM/tree/master/python-package#lightgbm-python-package.
 
 [tox]
-envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy
+envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy,py37
 
 [base]
 deps=


### PR DESCRIPTION
Prefer singledispatch from standard library
fallback on singledispatch package for older python versions

- This pr makes it possible to use eli5 with python 3.7.0
```
******/.env/lib/python3.7/site-packages/singledispatch_helpers.py in get_cache_token()
    157
    158 def get_cache_token():
--> 159     return ABCMeta._abc_invalidation_counter
    160
    161

AttributeError: type object 'ABCMeta' has no attribute '_abc_invalidation_counter'
```