### PR TITLE
Update xgboost titanic tutorial to xgboost==0.81

### DIFF
--- a/docs/update-notebooks.sh
+++ b/docs/update-notebooks.sh
@@ -52,9 +52,9 @@ jupyter nbconvert \
         --stdout \
         '../notebooks/xgboost-titanic.ipynb' \
         > source/_notebooks/xgboost-titanic.rst
-sed -i '' 's/eli5.show\\_weights/:func:`eli5.show_weights`/g' \
+sed -i '' 's/eli5.show_weights/:func:`eli5.show_weights`/g' \
     source/_notebooks/xgboost-titanic.rst
-sed -i '' 's/eli5.show\\_prediction/:func:`eli5.show_prediction`/g' \
+sed -i '' 's/eli5.show_prediction/:func:`eli5.show_prediction`/g' \
     source/_notebooks/xgboost-titanic.rst
 
 # LIME

--- a/notebooks/xgboost-titanic.ipynb
+++ b/notebooks/xgboost-titanic.ipynb
@@ -10,7 +10,7 @@
     "We will use [Titanic dataset](https://www.kaggle.com/c/titanic/data), which is small and has not too many\n",
     "features, but is still interesting enough.\n",
     "\n",
-    "We are using [XGBoost](https://xgboost.readthedocs.io/en/latest/) 0.6a2 and data downloaded from https://www.kaggle.com/c/titanic/data (it is also bundled in the eli5 repo: https://github.com/TeamHG-Memex/eli5/blob/master/notebooks/titanic-train.csv).\n",
+    "We are using [XGBoost](https://xgboost.readthedocs.io/en/latest/) 0.81 and data downloaded from https://www.kaggle.com/c/titanic/data (it is also bundled in the eli5 repo: https://github.com/TeamHG-Memex/eli5/blob/master/notebooks/titanic-train.csv).\n",
     "\n",
     "\n",
     "## 1. Training data\n",
@@ -112,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for x in all_xs:\n",
@@ -151,24 +149,14 @@
     }
    ],
    "source": [
-    "import warnings\n",
-    "# xgboost <= 0.6a2 shows a warning when used with scikit-learn 0.18+\n",
-    "warnings.filterwarnings('ignore', category=DeprecationWarning) \n",
     "from xgboost import XGBClassifier\n",
     "from sklearn.feature_extraction import DictVectorizer\n",
     "from sklearn.pipeline import make_pipeline\n",
     "from sklearn.model_selection import cross_val_score\n",
     "\n",
-    "class CSCTransformer:\n",
-    "    def transform(self, xs):\n",
-    "        # work around https://github.com/dmlc/xgboost/issues/1238#issuecomment-243872543\n",
-    "        return xs.tocsc()\n",
-    "    def fit(self, *args):\n",
-    "        return self\n",
-    "    \n",
     "clf = XGBClassifier()\n",
     "vec = DictVectorizer()\n",
-    "pipeline = make_pipeline(vec, CSCTransformer(), clf)\n",
+    "pipeline = make_pipeline(vec, clf)\n",
     "\n",
     "def evaluate(_clf):\n",
     "    scores = cross_val_score(_clf, all_xs, all_ys, scoring='accuracy', cv=10)\n",
@@ -182,10 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There is one tricky bit about the code above: XGBClassifier in xgboost 0.6a2 has some\n",
-    "[issues](https://github.com/dmlc/xgboost/issues/1238) with sparse data.\n",
-    "One way to solve them is to convert a sparse matrix to CSC format, so we add a ``CSCTransformer`` to the pipelne.\n",
-    "One may be templed to just pass ``dense=True`` to ``DictVectorizer``: after all, in this case the matrixes are small. But this is not a great solution, because we will loose the ability to distinguish features that are missing and features that have zero value.\n",
+    "There is one tricky bit about the code above: one may be templed to just pass ``dense=True`` to ``DictVectorizer``: after all, in this case the matrixes are small. But this is not a great solution, because we will loose the ability to distinguish features that are missing and features that have zero value.\n",
     "\n",
     "\n",
     "## 3. Explaining weights\n",
@@ -205,27 +190,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0:[Sex=female<-9.53674e-07] yes=1,no=2,missing=1\n",
+      "0:[Sex=female<-9.53674316e-07] yes=1,no=2,missing=1\n",
       "\t1:[Age<13] yes=3,no=4,missing=4\n",
       "\t\t3:[SibSp<2] yes=7,no=8,missing=7\n",
-      "\t\t\t7:leaf=0.145455\n",
+      "\t\t\t7:leaf=0.145454556\n",
       "\t\t\t8:leaf=-0.125\n",
-      "\t\t4:[Fare<26.2687] yes=9,no=10,missing=9\n",
-      "\t\t\t9:leaf=-0.151515\n",
-      "\t\t\t10:leaf=-0.0727273\n",
-      "\t2:[Pclass=3<-9.53674e-07] yes=5,no=6,missing=5\n",
-      "\t\t5:[Fare<12.175] yes=11,no=12,missing=12\n",
-      "\t\t\t11:leaf=0.05\n",
-      "\t\t\t12:leaf=0.175194\n",
-      "\t\t6:[Fare<24.8083] yes=13,no=14,missing=14\n",
-      "\t\t\t13:leaf=0.0365591\n",
-      "\t\t\t14:leaf=-0.152\n",
+      "\t\t4:[Fare<26.2687492] yes=9,no=10,missing=9\n",
+      "\t\t\t9:leaf=-0.151515156\n",
+      "\t\t\t10:leaf=-0.0727272779\n",
+      "\t2:[Pclass=3<-9.53674316e-07] yes=5,no=6,missing=5\n",
+      "\t\t5:[Fare<12.1750002] yes=11,no=12,missing=12\n",
+      "\t\t\t11:leaf=0.0500000007\n",
+      "\t\t\t12:leaf=0.175193802\n",
+      "\t\t6:[Fare<24.8083496] yes=13,no=14,missing=14\n",
+      "\t\t\t13:leaf=0.0365591422\n",
+      "\t\t\t14:leaf=-0.151999995\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "booster = clf.booster()\n",
+    "booster = clf.get_booster()\n",
     "original_feature_names = booster.feature_names\n",
     "booster.feature_names = vec.get_feature_names()\n",
     "print(booster.get_dump()[0])\n",
@@ -1201,7 +1186,7 @@
     "    ('All', DictVectorizer()),\n",
     "])\n",
     "clf2 = XGBClassifier()\n",
-    "pipeline2 = make_pipeline(vec2, CSCTransformer(), clf2)\n",
+    "pipeline2 = make_pipeline(vec2, clf2)\n",
     "evaluate(pipeline2)"
    ]
   },
@@ -2846,7 +2831,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #289

- use xgboost==0.81
- no warnings any more, remove their filtering
- the issue with xgboost + sparse matrices is no longer happening, so remove ``CSCTransformer``

Also I happened to have a newer pandoc version, which produces slightly different output (adjusted ``sed`` scripts accordingly) - @kmike what do you think, shall we stick to 1.x instead (nbconvert warns that is supports only 1.x)?