### PR TITLE
Apply pandoc 2.x to all notebooks

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,6 +1,6 @@
 Install extra python requirements to be able to build html docs locally::
 
-    pip install sphinx sphinx_rtd_theme -r requirements.txt
+    pip install -r requirements.txt
 
 Install `Pandoc <http://pandoc.org>`_ 2.x for notebook conversion.
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,5 +1,13 @@
+Install extra python requirements to be able to build html docs locally::
+
+    pip install sphinx sphinx_rtd_theme -r requirements.txt
+
+Install `Pandoc <http://pandoc.org>`_ 2.x for notebook conversion.
+
 To rebuild HTML docs, run ``make html``, then open
 ``_build/html/index.html`` file.
+Note that html docs are not checked it,
+rebuilding them is useful only to check how they will be rendered.
 
 To sync tutorials with IPython notebooks run ``update-notebooks.sh`` script,
 then rebuild the docs.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
+sphinx
+sphinx_rtd_theme
+
 ipython
 scipy
 numpy > 1.9.0

--- a/docs/source/_notebooks/debug-sklearn-crfsuite.rst
+++ b/docs/source/_notebooks/debug-sklearn-crfsuite.rst
@@ -52,7 +52,7 @@ encoding. CoNLL 2002 data also provide POS tags.
 2. Feature extraction
 ---------------------
 
-POS tags can be seen as pre-extracted features. Let's extract more
+POS tags can be seen as pre-extracted features. Let’s extract more
 features (word parts, simplified POS tags, lower/title/upper flags,
 features of nearby words) and convert them to sklear-crfsuite format -
 each sentence should be converted to a list of dicts. This is a very
@@ -154,7 +154,7 @@ This is how features extracted from a single token look like:
 --------------------
 
 Once we have features in a right format we can train a linear-chain CRF
-(Conditional Random Fields) model using sklearn\_crfsuite.CRF:
+(Conditional Random Fields) model using sklearn_crfsuite.CRF:
 
 .. code:: ipython3
 
@@ -171,8 +171,8 @@ Once we have features in a right format we can train a linear-chain CRF
 ------------------------
 
 CRFsuite CRF models use two kinds of features: state features and
-transition features. Let's check their weights using
-eli5.explain\_weights:
+transition features. Let’s check their weights using
+eli5.explain_weights:
 
 .. code:: ipython3
 
@@ -3905,16 +3905,16 @@ eli5.explain\_weights:
 
 Transition features make sense: at least model learned that I-ENITITY
 must follow B-ENTITY. It also learned that some transitions are
-unlikely, e.g. it is not common in this dataset to have a location right
+unlikely, e.g. it is not common in this dataset to have a location right
 after an organization name (I-ORG -> B-LOC has a large negative weight).
 
-Features don't use gazetteers, so model had to remember some geographic
-names from the training data, e.g. that España is a location.
+Features don’t use gazetteers, so model had to remember some geographic
+names from the training data, e.g. that España is a location.
 
 If we regularize CRF more, we can expect that only features which are
 generic will remain, and memoized tokens will go. With L1 regularization
 (c1 parameter) coefficients of most features should be driven to zero.
-Let's check what effect does regularization have on CRF weights:
+Let’s check what effect does regularization have on CRF weights:
 
 .. code:: ipython3
 
@@ -6220,19 +6220,19 @@ Let's check what effect does regularization have on CRF weights:
 As you can see, memoized tokens are mostly gone and model now relies on
 word shapes and POS tags. There is only a few non-zero features
 remaining. In our example the change probably made the quality worse,
-but that's a separate question.
+but that’s a separate question.
 
-Let's focus on transition weights. We can expect that O -> I-ENTIRY
+Let’s focus on transition weights. We can expect that O -> I-ENTIRY
 transitions to have large negative weights because they are impossible.
 But these transitions have zero weights, not negative weights, both in
 heavily regularized model and in our initial model. Something is going
 on here.
 
-The reason they are zero is that crfsuite haven't seen these transitions
+The reason they are zero is that crfsuite haven’t seen these transitions
 in training data, and assumed there is no need to learn weights for
 them, to save some computation time. This is the default behavior, but
-it is possible to turn it off using sklearn\_crfsuite.CRF
-``all_possible_transitions`` option. Let's check how does it affect the
+it is possible to turn it off using sklearn_crfsuite.CRF
+``all_possible_transitions`` option. Let’s check how does it affect the
 result:
 
 .. code:: ipython3
@@ -7342,7 +7342,7 @@ subset of labels:
 
 
 Another option is to check only some of the features - it helps to check
-if a feature function works as intended. For example, let's check how
+if a feature function works as intended. For example, let’s check how
 word shape features are used by model using ``feature_re`` argument and
 hide transition table:
 

--- a/docs/source/_notebooks/debug-sklearn-text.rst
+++ b/docs/source/_notebooks/debug-sklearn-text.rst
@@ -4,13 +4,13 @@ Debugging scikit-learn text classification pipeline
 
 scikit-learn docs provide a nice text classification
 `tutorial <http://scikit-learn.org/stable/tutorial/text_analytics/working_with_text_data.html>`__.
-Make sure to read it first. We'll be doing something similar to it,
+Make sure to read it first. We’ll be doing something similar to it,
 while taking more detailed look at classifier weights and predictions.
 
 1. Baseline model
 -----------------
 
-First, we need some data. Let's load 20 Newsgroups data, keeping only 4
+First, we need some data. Let’s load 20 Newsgroups data, keeping only 4
 categories:
 
 .. code:: ipython3
@@ -46,13 +46,13 @@ Regression as a classifier:
     pipe = make_pipeline(vec, clf)
     pipe.fit(twenty_train.data, twenty_train.target);
 
-We're using LogisticRegressionCV here to adjust regularization parameter
+We’re using LogisticRegressionCV here to adjust regularization parameter
 C automatically. It allows to compare different vectorizers - optimal C
-value could be different for different input features (e.g. for bigrams
+value could be different for different input features (e.g. for bigrams
 or for character-level input). An alternative would be to use
 GridSearchCV or RandomizedSearchCV.
 
-Let's check quality of this pipeline:
+Let’s check quality of this pipeline:
 
 .. code:: ipython3
 
@@ -84,7 +84,7 @@ Let's check quality of this pipeline:
 
 
 Not bad. We can try other classifiers and preprocessing methods, but
-let's check first what the model learned using :func:`eli5.show_weights`
+let’s check first what the model learned using :func:`eli5.show_weights`
 function:
 
 .. code:: ipython3
@@ -818,7 +818,7 @@ function:
 
 
 
-The table above doesn't make any sense; the problem is that eli5 was not
+The table above doesn’t make any sense; the problem is that eli5 was not
 able to get feature and class names from the classifier object alone. We
 can provide feature and target names explicitly:
 
@@ -1565,14 +1565,14 @@ and let eli5 figure out the details automatically:
 This starts to make more sense. Columns are target classes. In each
 column there are features and their weights. Intercept (bias) feature is
 shown as ``<BIAS>`` in the same table. We can inspect features and
-weights because we're using a bag-of-words vectorizer and a linear
+weights because we’re using a bag-of-words vectorizer and a linear
 classifier (so there is a direct mapping between individual words and
 classifier coefficients). For other classifiers features can be harder
 to inspect.
 
-Some features look good, but some don't. It seems model learned some
+Some features look good, but some don’t. It seems model learned some
 names specific to a dataset (email parts, etc.) though, instead of
-learning topic-specific words. Let's check prediction results on an
+learning topic-specific words. Let’s check prediction results on an
 example:
 
 .. code:: ipython3
@@ -2012,7 +2012,7 @@ example:
 
 
 What can be highlighted in text is highlighted in text. There is also a
-separate table for features which can't be highlighted in text -
+separate table for features which can’t be highlighted in text -
 ``<BIAS>`` in this case. If you hover mouse on a highlighted word it
 shows you a weight of this word in a title. Words are colored according
 to their weights.
@@ -2021,15 +2021,15 @@ to their weights.
 --------------------------------
 
 Aha, from the highlighting above it can be seen that a classifier
-learned some non-interesting stuff indeed, e.g. it remembered parts of
+learned some non-interesting stuff indeed, e.g. it remembered parts of
 email addresses. We should probably clean the data first to make it more
 interesting; improving model (trying different classifiers, etc.)
-doesn't make sense at this point - it may just learn to leverage these
+doesn’t make sense at this point - it may just learn to leverage these
 email addresses better.
 
-In practice we'd have to do cleaning yourselves; in this example 20
+In practice we’d have to do cleaning yourselves; in this example 20
 newsgroups dataset provides an option to remove footers and headers from
-the messages. Nice. Let's clean up the data and re-train a classifier.
+the messages. Nice. Let’s clean up the data and re-train a classifier.
 
 .. code:: ipython3
 
@@ -2081,14 +2081,14 @@ classifier allowed us to notice a problem with the data and made a good
 change, despite of numbers which told us not to do that.
 
 Instead of removing headers and footers we could have improved
-evaluation setup directly, using e.g. GroupKFold from scikit-learn. Then
+evaluation setup directly, using e.g. GroupKFold from scikit-learn. Then
 quality of old model would have dropped, we could have removed
 headers/footers and see increased accuracy, so the numbers would have
 told us to remove headers and footers. It is not obvious how to split
 data though, what groups to use with GroupKFold.
 
 So, what have the updated classifier learned? (output is less verbose
-because only a subset of classes is shown - see "targets" argument):
+because only a subset of classes is shown - see “targets” argument):
 
 .. code:: ipython3
 
@@ -2253,9 +2253,9 @@ because only a subset of classes is shown - see "targets" argument):
 
 
 
-Hm, it no longer uses email addresses, but it still doesn't look good:
-classifier assigns high weights to seemingly unrelated words like 'do'
-or 'my'. These words appear in many texts, so maybe classifier uses them
+Hm, it no longer uses email addresses, but it still doesn’t look good:
+classifier assigns high weights to seemingly unrelated words like ‘do’
+or ‘my’. These words appear in many texts, so maybe classifier uses them
 as a proxy for bias. Or maybe some of them are more common in some of
 classes.
 
@@ -2451,17 +2451,17 @@ To help classifier we may filter out stop words:
 
 
 
-Looks better, isn't it?
+Looks better, isn’t it?
 
-Alternatively, we can use TF\*IDF scheme; it should give a somewhat
+Alternatively, we can use TF*IDF scheme; it should give a somewhat
 similar effect.
 
-Note that we're cross-validating LogisticRegression regularisation
+Note that we’re cross-validating LogisticRegression regularisation
 parameter here, like in other examples (LogisticRegressionCV, not
-LogisticRegression). TF\*IDF values are different from word count
-values, so optimal C value can be different. We could draw a wrong
-conclusion if a classifier with fixed regularization strength is used -
-the chosen C value could have worked better for one kind of data.
+LogisticRegression). TF*IDF values are different from word count values,
+so optimal C value can be different. We could draw a wrong conclusion if
+a classifier with fixed regularization strength is used - the chosen C
+value could have worked better for one kind of data.
 
 .. code:: ipython3
 
@@ -2652,7 +2652,7 @@ the chosen C value could have worked better for one kind of data.
 
 
 
-It helped, but didn't have quite the same effect. Why not do both?
+It helped, but didn’t have quite the same effect. Why not do both?
 
 .. code:: ipython3
 
@@ -2847,7 +2847,7 @@ This starts to look good!
 ----------------------
 
 Maybe we can get somewhat better quality by choosing a different
-classifier, but let's skip it for now. Let's try other analysers instead
+classifier, but let’s skip it for now. Let’s try other analysers instead
 - use char n-grams instead of words:
 
 .. code:: ipython3
@@ -3253,10 +3253,10 @@ classifier, but let's skip it for now. Let's try other analysers instead
 
 It works, but quality is a bit worse. Also, it takes ages to train.
 
-It looks like stop\_words have no effect now - in fact, this is
-documented in scikit-learn docs, so our stop\_words='english' was
+It looks like stop_words have no effect now - in fact, this is
+documented in scikit-learn docs, so our stop_words=‘english’ was
 useless. But at least it is now more obvious how the text looks like for
-a char ngram-based classifier. Grab a cup of tea and see how char\_wb
+a char ngram-based classifier. Grab a cup of tea and see how char_wb
 looks like:
 
 .. code:: ipython3
@@ -3666,7 +3666,7 @@ unknown reason; maybe cross-word dependencies are not that important.
 ------------------------------
 
 To check that we can try fitting word n-grams instead of char n-grams.
-But let's deal with efficiency first. To handle large vocabularies we
+But let’s deal with efficiency first. To handle large vocabularies we
 can use HashingVectorizer from scikit-learn; to make training faster we
 can employ SGDCLassifier:
 
@@ -3697,8 +3697,8 @@ can employ SGDCLassifier:
     accuracy: 0.899
 
 
-It was super-fast! We're not choosing regularization parameter using
-cross-validation though. Let's check what model learned:
+It was super-fast! We’re not choosing regularization parameter using
+cross-validation though. Let’s check what model learned:
 
 .. code:: ipython3
 
@@ -3864,7 +3864,7 @@ cross-validation though. Let's check what model learned:
 
 
 Result looks similar to CountVectorizer. But with HashingVectorizer we
-don't even have a vocabulary! Why does it work?
+don’t even have a vocabulary! Why does it work?
 
 .. code:: ipython3
 
@@ -4597,9 +4597,9 @@ don't even have a vocabulary! Why does it work?
 
 
 
-Ok, we don't have a vocabulary, so we don't have feature names. Are we
+Ok, we don’t have a vocabulary, so we don’t have feature names. Are we
 out of luck? Nope, eli5 has an answer for that:
-:class:`~.InvertableHashingVectorizer` It can be used to get feature names for
+:class:`~.InvertableHashingVectorizer`. It can be used to get feature names for
 HahshingVectorizer without fitiing a huge vocabulary. It still needs
 some data to learn words -> hashes mapping though; we can use a random
 subset of data to fit it.
@@ -5747,11 +5747,11 @@ subset of data to fit it.
 
 
 
-There are collisions (hover mouse over features with "..."), and there
-are important features which were not seen in the random sample
-(FEATURE[...]), but overall it looks fine.
+There are collisions (hover mouse over features with “…”), and there are
+important features which were not seen in the random sample
+(FEATURE[…]), but overall it looks fine.
 
-"rutgers edu" bigram feature is suspicious though, it looks like a part
+“rutgers edu” bigram feature is suspicious though, it looks like a part
 of URL.
 
 .. code:: ipython3
@@ -5937,8 +5937,8 @@ something useful.
 
 
 Quoted text makes it too easy for model to classify some of the
-messages; that won't generalize to new messages. So to improve the model
-next step could be to process the data further, e.g. remove quoted text
+messages; that won’t generalize to new messages. So to improve the model
+next step could be to process the data further, e.g. remove quoted text
 or replace email addresses with a special token.
 
 You get the idea: looking at features helps to understand how classifier

--- a/docs/source/_notebooks/text-explainer.rst
+++ b/docs/source/_notebooks/text-explainer.rst
@@ -2,7 +2,7 @@
 TextExplainer: debugging black-box text classifiers
 ===================================================
 
-While eli5 supports many classifiers and preprocessing methods, it can't
+While eli5 supports many classifiers and preprocessing methods, it can’t
 support them all.
 
 If a library is not supported by eli5 directly, or the text processing
@@ -11,12 +11,12 @@ implementation of `LIME <http://arxiv.org/abs/1602.04938>`__ (Ribeiro et
 al., 2016) algorithm which allows to explain predictions of arbitrary
 classifiers, including text classifiers. ``eli5.lime`` can also help
 when it is hard to get exact mapping between model coefficients and text
-features, e.g. if there is dimension reduction involved.
+features, e.g. if there is dimension reduction involved.
 
 Example problem: LSA+SVM for 20 Newsgroups dataset
 --------------------------------------------------
 
-Let's load "20 Newsgroups" dataset and create a text processing pipeline
+Let’s load “20 Newsgroups” dataset and create a text processing pipeline
 which is hard to debug using conventional methods: SVM with RBF kernel
 trained on
 `LSA <https://en.wikipedia.org/wiki/Latent_semantic_analysis>`__
@@ -634,11 +634,11 @@ metrics in ``metrics_`` attribute:
 
 
 
--  'score' is an accuracy score weighted by cosine distance between
-   generated sample and the original document (i.e. texts which are
+-  ‘score’ is an accuracy score weighted by cosine distance between
+   generated sample and the original document (i.e. texts which are
    closer to the example are more important). Accuracy shows how good
-   are 'top 1' predictions.
--  'mean\_KL\_divergence' is a mean `Kullback–Leibler
+   are ‘top 1’ predictions.
+-  ‘mean_KL_divergence’ is a mean `Kullback–Leibler
    divergence <https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence>`__
    for all target classes; it is also weighted by distance. KL
    divergence shows how well are probabilities approximated; 0.0 means a
@@ -648,33 +648,33 @@ In this example both accuracy and KL divergence are good; it means our
 white-box classifier usually assigns the same labels as the black-box
 classifier on the dataset we generated, and its predicted probabilities
 are close to those predicted by our LSA+SVM pipeline. So it is likely
-(though not guaranteed, we'll discuss it later) that the explanation is
+(though not guaranteed, we’ll discuss it later) that the explanation is
 correct and can be trusted.
 
-When working with LIME (e.g. via :class:`~.TextExplainer`) it is always a good
+When working with LIME (e.g. via :class:`~.TextExplainer`) it is always a good
 idea to check these scores. If they are not good then you can tell that
 something is not right.
 
-Let's make it fail
+Let’s make it fail
 ------------------
 
 By default :class:`~.TextExplainer` uses a very basic text processing pipeline:
 Logistic Regression trained on bag-of-words and bag-of-bigrams features
 (see ``te.clf_`` and ``te.vec_`` attributes). It limits a set of
-black-box classifiers it can explain: because the text is seen as "bag
-of words/ngrams", the default white-box pipeline can't distinguish e.g.
-between the same word in the beginning of the document and in the end of
-the document. Bigrams help to alleviate the problem in practice, but not
-completely.
+black-box classifiers it can explain: because the text is seen as “bag
+of words/ngrams”, the default white-box pipeline can’t distinguish
+e.g. between the same word in the beginning of the document and in the
+end of the document. Bigrams help to alleviate the problem in practice,
+but not completely.
 
-Black-box classifiers which use features like "text length" (not
+Black-box classifiers which use features like “text length” (not
 directly related to tokens) can be also hard to approximate using the
 default bag-of-words/ngrams model.
 
 This kind of failure is usually detectable though - scores (accuracy and
-KL divergence) will be low. Let's check it on a completely synthetic
+KL divergence) will be low. Let’s check it on a completely synthetic
 example - a black-box classifier which assigns a class based on oddity
-of document length and on a presence of 'medication' word.
+of document length and on a presence of ‘medication’ word.
 
 .. code:: ipython3
 
@@ -849,8 +849,8 @@ of document length and on a presence of 'medication' word.
 
 
 
-:class:`~.TextExplainer` correctly figured out that 'medication' is important,
-but failed to account for "len(doc) % 2" condition, so the explanation
+:class:`~.TextExplainer` correctly figured out that ‘medication’ is important,
+but failed to account for “len(doc) % 2” condition, so the explanation
 is incomplete. We can detect this failure by looking at metrics - they
 are low:
 
@@ -867,11 +867,11 @@ are low:
 
 
 
-If (a big if...) we suspect that the fact document length is even or odd
+If (a big if…) we suspect that the fact document length is even or odd
 is important, it is possible to customize :class:`~.TextExplainer` to check
 this hypothesis.
 
-To do that, we need to create a vectorizer which returns both "is odd"
+To do that, we need to create a vectorizer which returns both “is odd”
 feature and bag-of-words features, and pass this vectorizer to
 :class:`~.TextExplainer`. This vectorizer should follow scikit-learn API. The
 easiest way is to use ``FeatureUnion`` - just make sure all transformers
@@ -1081,7 +1081,7 @@ Much better! It was a toy example, but the idea stands - if you think
 something could be important, add it to the mix as a feature for
 :class:`~.TextExplainer`.
 
-Let's make it fail, again
+Let’s make it fail, again
 -------------------------
 
 Another possible issue is the dataset generation method. Not only
@@ -1089,8 +1089,8 @@ feature extraction should be powerful enough, but auto-generated texts
 also should be diverse enough.
 
 :class:`~.TextExplainer` removes random words by default, so by default it
-can't e.g. provide a good explanation for a black-box classifier which
-works on character level. Let's try to use :class:`~.TextExplainer` to explain
+can’t e.g. provide a good explanation for a black-box classifier which
+works on character level. Let’s try to use :class:`~.TextExplainer` to explain
 a classifier which uses char ngrams as features:
 
 .. code:: ipython3
@@ -1115,8 +1115,8 @@ a classifier which uses char ngrams as features:
 
 
 This pipeline is supported by eli5 directly, so in practice there is no
-need to use :class:`~.TextExplainer` for it. We're using this pipeline as an
-example - it is possible check the "true" explanation first, without
+need to use :class:`~.TextExplainer` for it. We’re using this pipeline as an
+example - it is possible check the “true” explanation first, without
 using :class:`~.TextExplainer`, and then compare the results with
 :class:`~.TextExplainer` results.
 
@@ -1453,7 +1453,7 @@ first sight, but we know that the classifier works in a different way.
 
 To explain such black-box classifiers we need to change both dataset
 generation method (change/remove individual characters, not only words)
-and feature extraction method (e.g. use char ngrams instead of words and
+and feature extraction method (e.g. use char ngrams instead of words and
 word ngrams).
 
 :class:`~.TextExplainer` has an option (``char_based=True``) to use char-based
@@ -1626,8 +1626,8 @@ explanation engine why not always use it?
 
 
 Hm, the result look worse. :class:`~.TextExplainer` detected correctly that
-only the first part of word "medication" is important, but the result is
-noisy overall, and scores are bad. Let's try it with more samples:
+only the first part of word “medication” is important, but the result is
+noisy overall, and scores are bad. Let’s try it with more samples:
 
 .. code:: ipython3
 
@@ -1802,15 +1802,15 @@ training the original pipeline.
 Generally speaking, to do an efficient explanation we should make some
 assumptions about black-box classifier, such as:
 
-1. it uses words as features and doesn't take word position in account;
+1. it uses words as features and doesn’t take word position in account;
 2. it uses words as features and takes word positions in account;
 3. it uses words ngrams as features;
-4. it uses char ngrams as features, positions don't matter (i.e. an
+4. it uses char ngrams as features, positions don’t matter (i.e. an
    ngram means the same everywhere);
-5. it uses arbitrary attention over the text characters, i.e. every part
+5. it uses arbitrary attention over the text characters, i.e. every part
    of text could be potentionally important for a classifier on its own;
 6. it is important to have a particular token at a particular position,
-   e.g. "third token is X", and if we delete 2nd token then prediction
+   e.g. “third token is X”, and if we delete 2nd token then prediction
    changes not because 2nd token changed, but because 3rd token is
    shifted.
 
@@ -1828,12 +1828,12 @@ On the other hand, allowing for each character to be important is a more
 powerful method, but it can require a lot of samples (maybe hundreds
 thousands) and a lot of CPU time to get non-noisy results.
 
-What's bad about this kind of failure (wrong assumption about the
+What’s bad about this kind of failure (wrong assumption about the
 black-box pipeline) is that it could be impossible to detect the failure
 by looking at the scores. Scores could be high because generated dataset
 is not diverse enough, not because our approximation is good.
 
-The takeaway is that it is important to understand the "lenses" you're
+The takeaway is that it is important to understand the “lenses” you’re
 looking through when using LIME to explain a prediction.
 
 Customizing TextExplainer: sampling
@@ -1845,7 +1845,7 @@ main text generation class; :class:`~.MaskingTextSamplers` provides a way to
 combine multiple samplers in a single object with the same interface.
 
 A custom sampler instance can be passed to :class:`~.TextExplainer` if we want
-to experiment with sampling. For example, let's try a sampler which
+to experiment with sampling. For example, let’s try a sampler which
 replaces no more than 3 characters in the text (default is to replace a
 random number of characters):
 
@@ -2047,17 +2047,17 @@ random number of characters):
 
 
 Note that accuracy score is perfect, but KL divergence is bad. It means
-this sampler was not very useful: most generated texts were "easy" in
+this sampler was not very useful: most generated texts were “easy” in
 sense that most (or all?) of them should be still classified as
 ``sci.med``, so it was easy to get a good accuracy. But because
-generated texts were not diverse enough classifier haven't learned
-anything useful; it's having a hard time predicting the probability
+generated texts were not diverse enough classifier haven’t learned
+anything useful; it’s having a hard time predicting the probability
 output of the black-box pipeline on a held-out dataset.
 
 By default :class:`~.TextExplainer` uses a mix of several sampling strategies
 which seems to work OK for token-based explanations. But a good sampling
 strategy which works for many real-world tasks could be a research topic
-on itself. If you've got some experience with it we'd love to hear from
+on itself. If you’ve got some experience with it we’d love to hear from
 you - please share your findings in eli5 issue tracker (
 https://github.com/TeamHG-Memex/eli5/issues )!
 
@@ -2282,10 +2282,10 @@ decision tree:
 
 
 
-How to read it: "kidney <= 0.5" means "word 'kidney' is not in the
-document" (we're explaining the orginal LDA+SVM pipeline again).
+How to read it: “kidney <= 0.5” means “word ‘kidney’ is not in the
+document” (we’re explaining the orginal LDA+SVM pipeline again).
 
-So according to this tree if "kidney" is not in the document and "pain"
+So according to this tree if “kidney” is not in the document and “pain”
 is not in the document then the probability of a document belonging to
 ``sci.med`` drops to ``0.65``. If at least one of these words remain
 ``sci.med`` probability stays ``0.9+``.

--- a/docs/update-notebooks.sh
+++ b/docs/update-notebooks.sh
@@ -7,10 +7,10 @@ jupyter nbconvert \
         '../notebooks/Debugging scikit-learn text classification pipeline.ipynb' \
         > source/_notebooks/debug-sklearn-text.rst
 
-sed -i '' 's/InvertableHashingVectorizer\./:class:`~.InvertableHashingVectorizer`/g' \
+sed -i '' 's/``InvertableHashingVectorizer``/:class:`~.InvertableHashingVectorizer`/g' \
     source/_notebooks/debug-sklearn-text.rst
 
-sed -i '' 's/eli5.show\\_weights/:func:`eli5.show_weights`/g' \
+sed -i '' 's/``eli5.show_weights``/:func:`eli5.show_weights`/g' \
     source/_notebooks/debug-sklearn-text.rst
 
 # sklearn-crfsuite tutorial
@@ -52,9 +52,9 @@ jupyter nbconvert \
         --stdout \
         '../notebooks/xgboost-titanic.ipynb' \
         > source/_notebooks/xgboost-titanic.rst
-sed -i '' 's/eli5.show_weights/:func:`eli5.show_weights`/g' \
+sed -i '' 's/``eli5.show_weights``/:func:`eli5.show_weights`/g' \
     source/_notebooks/xgboost-titanic.rst
-sed -i '' 's/eli5.show_prediction/:func:`eli5.show_prediction`/g' \
+sed -i '' 's/``eli5.show_prediction``/:func:`eli5.show_prediction`/g' \
     source/_notebooks/xgboost-titanic.rst
 
 # LIME

--- a/notebooks/Debugging scikit-learn text classification pipeline.ipynb
+++ b/notebooks/Debugging scikit-learn text classification pipeline.ipynb
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Not bad. We can try other classifiers and preprocessing methods, but let's check first what the model learned using eli5.show_weights function:"
+    "Not bad. We can try other classifiers and preprocessing methods, but let's check first what the model learned using ``eli5.show_weights`` function:"
    ]
   },
   {
@@ -4805,7 +4805,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, we don't have a vocabulary, so we don't have feature names. Are we out of luck? Nope, eli5 has an answer for that: InvertableHashingVectorizer. It can be used to get feature names for HahshingVectorizer without fitiing a huge vocabulary. It still needs some data to learn words -> hashes mapping though; we can use a random subset of data to fit it."
+    "Ok, we don't have a vocabulary, so we don't have feature names. Are we out of luck? Nope, eli5 has an answer for that: ``InvertableHashingVectorizer``. It can be used to get feature names for HahshingVectorizer without fitiing a huge vocabulary. It still needs some data to learn words -> hashes mapping though; we can use a random subset of data to fit it."
    ]
   },
   {
@@ -6209,7 +6209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/notebooks/xgboost-titanic.ipynb
+++ b/notebooks/xgboost-titanic.ipynb
@@ -224,7 +224,7 @@
    "source": [
     "We see that this tree checks *Sex*, *Age*, *Pclass*, *Fare* and *SibSp* features. ``leaf`` gives the decision of a single tree, and they are summed over all trees in the ensemble.\n",
     "\n",
-    "Let's check feature importances with eli5.show_weights:"
+    "Let's check feature importances with ``eli5.show_weights``:"
    ]
   },
   {
@@ -544,7 +544,7 @@
     "\n",
     "## 4. Explaining predictions\n",
     "\n",
-    "To get a better idea of how our classifier works, let's examine individual predictions with eli5.show_prediction:"
+    "To get a better idea of how our classifier works, let's examine individual predictions with ``eli5.show_prediction``:"
    ]
   },
   {


### PR DESCRIPTION
Also adjust ``sed`` scripts: use double back-ticks everywhere, otherwise functions inside code blocks were also replaced.

I checked that ``TF*IDF`` is rendered fine without escaping of ``*`` (and other escape removals).

Followup to #291 