### PR TITLE
Fix the build: fix test for newer numpy

### DIFF
--- a/eli5/utils.py
+++ b/eli5/utils.py
@@ -65,7 +65,7 @@ def indices_to_bool_mask(indices, size):
     >>> indices_to_bool_mask(np.array([5]), 2)
     Traceback (most recent call last):
     ...
-    IndexError: index 5 is out of bounds for axis 1 with size 2
+    IndexError: index 5 is out of bounds ...
     """
     mask = np.zeros(size, dtype=bool)
     mask[indices] = 1


### PR DESCRIPTION
Exception message is different now:
```
IndexError: index 5 is out of bounds for axis 0 with size 2
```
while it used to be:
```
IndexError: index 5 is out of bounds for axis 1 with size 2
```
the new one makes more sense, as this is a 1d-array.