### PR TITLE
Fix #298 Handle removal of sklearn randomized l1 models

### DIFF
--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -18,6 +18,7 @@ from eli5.sklearn.utils import get_feature_names as _get_feature_names
 
 # Feature selection:
 
+@transform_feature_names.register(SelectorMixin)
 def _select_names(est, in_names=None):
     mask = est.get_support(indices=False)
     in_names = _get_feature_names(est, feature_names=in_names,
@@ -33,7 +34,6 @@ try:
     _select_names = transform_feature_names.register(RandomizedLogisticRegression)(_select_names)
 except ImportError:     # Removed in scikit-learn 0.21
     pass
-_select_names = transform_feature_names.register(SelectorMixin)(_select_names)
 
 
 # Scaling

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -4,10 +4,7 @@
 import numpy as np  # type: ignore
 from sklearn.pipeline import Pipeline, FeatureUnion  # type: ignore
 from sklearn.feature_selection.base import SelectorMixin  # type: ignore
-from sklearn.linear_model import (  # type: ignore
-    RandomizedLogisticRegression,
-    RandomizedLasso,
-)
+
 from sklearn.preprocessing import (  # type: ignore
     MinMaxScaler,
     StandardScaler,
@@ -21,14 +18,22 @@ from eli5.sklearn.utils import get_feature_names as _get_feature_names
 
 # Feature selection:
 
-@transform_feature_names.register(SelectorMixin)
-@transform_feature_names.register(RandomizedLogisticRegression)
-@transform_feature_names.register(RandomizedLasso)
 def _select_names(est, in_names=None):
     mask = est.get_support(indices=False)
     in_names = _get_feature_names(est, feature_names=in_names,
                                   num_features=len(mask))
     return [in_names[i] for i in np.flatnonzero(mask)]
+
+try:
+    from sklearn.linear_model import (  # type: ignore
+        RandomizedLogisticRegression,
+        RandomizedLasso,
+    )
+    _select_names = transform_feature_names.register(RandomizedLasso)(_select_names)
+    _select_names = transform_feature_names.register(RandomizedLogisticRegression)(_select_names)
+except ImportError:     # Removed in scikit-learn 0.21
+    pass
+_select_names = transform_feature_names.register(SelectorMixin)(_select_names)
 
 
 # Scaling


### PR DESCRIPTION
Fixes #298 
Wrap import and decorators in a try-except block.