### PR TITLE
Fix #304. Allow ELI5 to import despite improperly installed LightGBM

### DIFF
--- a/eli5/__init__.py
+++ b/eli5/__init__.py
@@ -73,3 +73,12 @@ try:
 except ImportError:
     # lightgbm is not available
     pass
+except OSError:
+    # improperly installed lightgbm
+    pass
+except Exception as e:
+    if e.__class__.__name__ == 'LightGBMError':
+        # improperly installed lightgbm
+        pass
+    else:
+        raise

--- a/eli5/__init__.py
+++ b/eli5/__init__.py
@@ -76,9 +76,3 @@ except ImportError:
 except OSError:
     # improperly installed lightgbm
     pass
-except Exception as e:
-    if e.__class__.__name__ == 'LightGBMError':
-        # improperly installed lightgbm
-        pass
-    else:
-        raise


### PR DESCRIPTION
Fixes #304.
Catch and pass on OSError when importing broken LightGBM (library load fails - https://github.com/Microsoft/LightGBM/issues/1369).