### PR TITLE
Add scikit-learn-contrib/stability-selection and improve randomized_l1 transformers

### DIFF
--- a/docs/source/libraries/sklearn.rst
+++ b/docs/source/libraries/sklearn.rst
@@ -261,6 +261,8 @@ Currently the following transformers are supported out of the box:
 * SelectorMixin-based transformers: SelectPercentile_,
   SelectKBest_, GenericUnivariateSelect_, VarianceThreshold_,
   RFE_, RFECV_, SelectFromModel_, RandomizedLogisticRegression_;
+* stability selection-based transformers: RandomizedLogisticRegression_, 
+  RandomizedLasso_, StabilitySelection_;
 * scalers from sklearn.preprocessing: MinMaxScaler_, StandardScaler_,
   MaxAbsScaler_, RobustScaler_.
 
@@ -276,6 +278,8 @@ Currently the following transformers are supported out of the box:
 .. _RFECV: http://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.RFECV.html
 .. _VarianceThreshold: http://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.VarianceThreshold.html
 .. _RandomizedLogisticRegression: http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RandomizedLogisticRegression.html
+.. _RandomizedLasso: https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.RandomizedLasso.html
+.. _StabilitySelection: https://github.com/scikit-learn-contrib/stability-selection
 .. _Pipeline: http://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn.pipeline.Pipeline
 .. _singledispatch: https://pypi.python.org/pypi/singledispatch
 

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -32,7 +32,16 @@ try:
     )
     _select_names = transform_feature_names.register(RandomizedLasso)(_select_names)
     _select_names = transform_feature_names.register(RandomizedLogisticRegression)(_select_names)
-except ImportError:     # Removed in scikit-learn 0.21
+except ImportError:     
+    # randomized_l1 was removed in scikit-learn 0.21
+    pass
+
+try:
+    from stability_selection import StabilitySelection
+    _select_names = transform_feature_names.register(StabilitySelection)(_select_names)
+    # TODO: add support for stability_selection.RandomizedLogisticRegression and stability_selection.RandomizedLasso ?
+except ImportError:
+    # scikit-learn-contrib/stability-selection is not available
     pass
 
 

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -14,7 +14,7 @@ except ImportError:
     RandomizedLogisticRegression = None
     RandomizedLasso = None
 try:
-    from stability_selection import StabilitySelection
+    from stability_selection import StabilitySelection # type: ignore
     # TODO: add support for stability_selection.RandomizedLogisticRegression and stability_selection.RandomizedLasso ?
 except ImportError:
     # scikit-learn-contrib/stability-selection is not available

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 import numpy as np
-import sklearn
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import (
     SelectPercentile,
@@ -41,6 +40,7 @@ from sklearn.preprocessing import (
 )
 from sklearn.pipeline import FeatureUnion, make_pipeline
 
+from .utils import sklearn_version
 from eli5 import transform_feature_names
 from eli5.sklearn import PermutationImportance
 
@@ -62,12 +62,6 @@ def selection_score_func(X, y):
 
 def instantiate_notnone(cls, *args, **kwargs):
     return cls(*args, **kwargs) if cls is not None else None
-
-
-def parse_version(mod):
-    v = mod.__version__
-    vint = list(map(int, v.split('.')))
-    return vint
 
 
 @pytest.mark.parametrize('transformer,expected', [
@@ -123,14 +117,14 @@ def parse_version(mod):
         instantiate_notnone(RandomizedLasso, random_state=42),
         ['<NAME1>', '<NAME2>', '<NAME3>'],
         marks=pytest.mark.skipif(
-            parse_version(sklearn)[1] < 19 or RandomizedLasso is None,
+            sklearn_version() < '0.19' or RandomizedLasso is None,
             reason='scikit-learn < 0.19 or RandomizedLasso is not available')
     ),
     pytest.param(
         instantiate_notnone(RandomizedLasso, random_state=42),
         ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>'],
         marks=pytest.mark.skipif(
-            19 <= parse_version(sklearn)[1] or RandomizedLasso is None,
+            '0.19' <= sklearn_version() or RandomizedLasso is None,
             reason='scikit-learn >= 0.19 or RandomizedLasso is not available') 
     ),
     pytest.param(

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -109,29 +109,31 @@ def instantiate_notnone(cls, *args, **kwargs):
     pytest.param(
         instantiate_notnone(RandomizedLogisticRegression, random_state=42),
         ['<NAME1>', '<NAME2>', '<NAME3>'],
-        marks=pytest.mark.skipif(
-            RandomizedLogisticRegression is None,
+        marks=pytest.mark.skipif(RandomizedLogisticRegression is None,
             reason='scikit-learn RandomizedLogisticRegression is not available')
     ),
     pytest.param(
         instantiate_notnone(RandomizedLasso, random_state=42),
         ['<NAME1>', '<NAME2>', '<NAME3>'],
-        marks=pytest.mark.skipif(
-            sklearn_version() < '0.19' or RandomizedLasso is None,
-            reason='scikit-learn < 0.19 or RandomizedLasso is not available')
+        marks=[
+            pytest.mark.skipif(RandomizedLasso is None,
+                reason='RandomizedLasso is not available'),
+            pytest.mark.skipif(sklearn_version() < '0.19',
+                reason='scikit-learn < 0.19')]
     ),
     pytest.param(
         instantiate_notnone(RandomizedLasso, random_state=42),
         ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>'],
-        marks=pytest.mark.skipif(
-            '0.19' <= sklearn_version() or RandomizedLasso is None,
-            reason='scikit-learn >= 0.19 or RandomizedLasso is not available') 
+        marks=[
+            pytest.mark.skipif(RandomizedLasso is None, 
+                reason='RandomizedLasso is not available'),
+            pytest.mark.skipif('0.19' <= sklearn_version(),
+                reason='scikit-learn >= 0.19')]
     ),
     pytest.param(
         instantiate_notnone(StabilitySelection, random_state=42),
         ['<NAME2>'],
-        marks=pytest.mark.skipif(
-            StabilitySelection is None,
+        marks=pytest.mark.skipif(StabilitySelection is None,
             reason='scikit-learn-contrib/stability-selection is not available')
     ),
 ])

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 import numpy as np
+import sklearn
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.feature_selection import (
     SelectPercentile,
@@ -63,6 +64,12 @@ def instantiate_notnone(cls, *args, **kwargs):
     return cls(*args, **kwargs) if cls is not None else None
 
 
+def parse_version(mod):
+    v = mod.__version__
+    vint = list(map(int, v.split('.')))
+    return vint
+
+
 @pytest.mark.parametrize('transformer,expected', [
     (MyFeatureExtractor(), ['f1', 'f2', 'f3']),
 
@@ -116,8 +123,15 @@ def instantiate_notnone(cls, *args, **kwargs):
         instantiate_notnone(RandomizedLasso, random_state=42),
         ['<NAME1>', '<NAME2>', '<NAME3>'],
         marks=pytest.mark.skipif(
-            RandomizedLasso is None,
-            reason='scikit-learn RandomizedLasso is not available')
+            parse_version(sklearn)[1] < 19 or RandomizedLasso is None,
+            reason='scikit-learn < 0.19 or RandomizedLasso is not available')
+    ),
+    pytest.param(
+        instantiate_notnone(RandomizedLasso, random_state=42),
+        ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>'],
+        marks=pytest.mark.skipif(
+            19 <= parse_version(sklearn)[1] or RandomizedLasso is None,
+            reason='scikit-learn >= 0.19 or RandomizedLasso is not available') 
     ),
     pytest.param(
         instantiate_notnone(StabilitySelection, random_state=42),

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function
 import re
 
 import pytest
@@ -15,11 +17,21 @@ from sklearn.feature_selection import (
     RFECV,
     SelectFromModel,
 )
-from sklearn.linear_model import (
-    LogisticRegression,
-    RandomizedLogisticRegression,
-    RandomizedLasso,  # TODO: add tests and document
-)
+from sklearn.linear_model import LogisticRegression
+try:
+    from sklearn.linear_model import (
+        RandomizedLogisticRegression,
+        RandomizedLasso,
+    )
+except ImportError:
+    # randomized_l1 feature selectors are not available (removed in scikit-learn 0.21)
+    RandomizedLogisticRegression = None
+    RandomizedLasso = None
+try:
+    from stability_selection import StabilitySelection
+except ImportError:
+    # scikit-learn-contrib/stability-selection is not available
+    StabilitySelection = None
 from sklearn.preprocessing import (
     MinMaxScaler,
     StandardScaler,
@@ -45,6 +57,10 @@ class MyFeatureExtractor(BaseEstimator, TransformerMixin):
 
 def selection_score_func(X, y):
     return np.array([1, 2, 3, 4])
+
+
+def instantiate_notnone(cls, *args, **kwargs):
+    return cls(*args, **kwargs) if cls is not None else None
 
 
 @pytest.mark.parametrize('transformer,expected', [
@@ -88,8 +104,28 @@ def selection_score_func(X, y):
      ['<NAME1>', '<NAME3>']),
     (RFECV(LogisticRegression(random_state=42)),
      ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
-    (RandomizedLogisticRegression(random_state=42),
-     ['<NAME1>', '<NAME2>', '<NAME3>']),
+
+    pytest.param(
+        instantiate_notnone(RandomizedLogisticRegression, random_state=42),
+        ['<NAME1>', '<NAME2>', '<NAME3>'],
+        marks=pytest.mark.skipif(
+            RandomizedLogisticRegression is None,
+            reason='scikit-learn RandomizedLogisticRegression is not available')
+    ),
+    pytest.param(
+        instantiate_notnone(RandomizedLasso, random_state=42),
+        ['<NAME1>', '<NAME2>', '<NAME3>'],
+        marks=pytest.mark.skipif(
+            RandomizedLasso is None,
+            reason='scikit-learn RandomizedLasso is not available')
+    ),
+    pytest.param(
+        instantiate_notnone(StabilitySelection, random_state=42),
+        ['<NAME2>'],
+        marks=pytest.mark.skipif(
+            StabilitySelection is None,
+            reason='scikit-learn-contrib/stability-selection is not available')
+    ),
 ])
 def test_transform_feature_names_iris(transformer, expected, iris_train):
     X, y, _, _ = iris_train


### PR DESCRIPTION
Closes #305.
* Take ```stability_selection.StabilitySelection```(https://github.com/scikit-learn-contrib/stability-selection) as an argument to ```transform_feature_names```. 
* Add stability selection tests.
* Mention stability selection in the docs.
* Register possibly missing dependencies through a wrapper. See @lopuhin's suggestions  https://github.com/TeamHG-Memex/eli5/pull/302#discussion_r269882856. 

Coverage should increase once scikit-learn 0.21 and scikit-learn-contrib/stability-selection are tested against (could modify the tox config for this?).

If more use cases come up for functions like ```register_notnone``` and ```instantiate_notnone```, they could be moved to ```base_utils.py``` or similar.