### PR TITLE
Compatibility with scikit-learn 0.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: trusty
+dist: xenial
 sudo: required
 branches:
     only:

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -558,11 +558,12 @@ def _trees_feature_weights(clf, X, feature_names, num_targets):
     """ Return feature weights for a tree or a tree ensemble.
     """
     feature_weights = np.zeros([len(feature_names), num_targets])
+    is_grad_boost = isinstance(clf, (GradientBoostingClassifier,
+                                     GradientBoostingRegressor))
     if hasattr(clf, 'tree_'):
         _update_tree_feature_weights(X, feature_names, clf, feature_weights)
     else:
-        if isinstance(clf, (
-                GradientBoostingClassifier, GradientBoostingRegressor)):
+        if is_grad_boost:
             weight = clf.learning_rate
         else:
             weight = 1. / len(clf.estimators_)
@@ -578,7 +579,15 @@ def _trees_feature_weights(clf, X, feature_names, num_targets):
                 _update(_clfs, feature_weights)
         feature_weights *= weight
         if hasattr(clf, 'init_'):
-            feature_weights[feature_names.bias_idx] += clf.init_.predict(X)[0]
+            if is_grad_boost:
+                if clf.init_ == 'zero':
+                    bias_init = 0
+                else:
+                    bias_init = clf.loss_.get_init_raw_predictions(
+                        X, clf.init_).astype(np.float64)[0]
+            else:
+                 bias_init = clf.init_.predict(X)[0]
+            feature_weights[feature_names.bias_idx] += bias_init
     return feature_weights
 
 

--- a/eli5/sklearn/explain_prediction.py
+++ b/eli5/sklearn/explain_prediction.py
@@ -579,14 +579,13 @@ def _trees_feature_weights(clf, X, feature_names, num_targets):
                 _update(_clfs, feature_weights)
         feature_weights *= weight
         if hasattr(clf, 'init_'):
-            if is_grad_boost:
-                if clf.init_ == 'zero':
-                    bias_init = 0
-                else:
-                    bias_init = clf.loss_.get_init_raw_predictions(
-                        X, clf.init_).astype(np.float64)[0]
+            if clf.init_ == 'zero':
+                bias_init = 0
+            elif is_grad_boost and hasattr(clf.loss_, 'get_init_raw_predictions'):
+                bias_init = clf.loss_.get_init_raw_predictions(
+                    X, clf.init_).astype(np.float64)[0]
             else:
-                 bias_init = clf.init_.predict(X)[0]
+                bias_init = clf.init_.predict(X)[0]
             feature_weights[feature_names.bias_idx] += bias_init
     return feature_weights
 

--- a/tests/test_sklearn_explain_prediction.py
+++ b/tests/test_sklearn_explain_prediction.py
@@ -474,7 +474,8 @@ def test_explain_linear_regression_multitarget(reg):
 @pytest.mark.parametrize(['clf'], [
     [DecisionTreeClassifier(random_state=42)],
     [ExtraTreesClassifier(random_state=42)],
-    [GradientBoostingClassifier(learning_rate=0.075, random_state=42)],
+    [GradientBoostingClassifier(learning_rate=0.075, random_state=42),],
+    [GradientBoostingClassifier(learning_rate=0.075, random_state=42, init='zero'),],
     [RandomForestClassifier(random_state=42)],
 ])
 def test_explain_tree_clf_multiclass(clf, iris_train):

--- a/tests/test_sklearn_transform.py
+++ b/tests/test_sklearn_transform.py
@@ -15,11 +15,18 @@ from sklearn.feature_selection import (
     RFECV,
     SelectFromModel,
 )
-from sklearn.linear_model import (
-    LogisticRegression,
-    RandomizedLogisticRegression,
-    RandomizedLasso,  # TODO: add tests and document
-)
+from sklearn.linear_model import LogisticRegression
+_additional_test_cases = []
+try:
+    from sklearn.linear_model import (  # type: ignore
+        RandomizedLogisticRegression,
+        RandomizedLasso,  # TODO: add tests and document
+    )
+    _additional_test_cases.append(
+        (RandomizedLogisticRegression(random_state=42),
+         ['<NAME1>', '<NAME2>', '<NAME3>']))
+except ImportError:     # Removed in scikit-learn 0.21
+    pass
 from sklearn.preprocessing import (
     MinMaxScaler,
     StandardScaler,
@@ -88,9 +95,7 @@ def selection_score_func(X, y):
      ['<NAME1>', '<NAME3>']),
     (RFECV(LogisticRegression(random_state=42)),
      ['<NAME0>', '<NAME1>', '<NAME2>', '<NAME3>']),
-    (RandomizedLogisticRegression(random_state=42),
-     ['<NAME1>', '<NAME2>', '<NAME3>']),
-])
+] + _additional_test_cases)
 def test_transform_feature_names_iris(transformer, expected, iris_train):
     X, y, _, _ = iris_train
     transformer.fit(X, y)

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ commands=
 
 [testenv:py36-legacy]
 commands=
+    pip install "scipy < 1.0.0"
     pip install "scikit-learn < 0.19"
     pip install "numpy < 1.14"
     pip install "xgboost == 0.6a2"


### PR DESCRIPTION
Some changes have been introduced to be compatible with scikit-learn 0.21:

- [x] Fix Randomized(LogisticRegression|Lasso) test fail for scikit-learn 0.21 (related to https://github.com/TeamHG-Memex/eli5/pull/302/files)
- [x] Fix xgboost installation failure by changing distro from trusty to xenial
- [x] Fix legacy tox build by specifying the scipy version
- [x] Fix init GradientBoostingClassifier changes introduced in scikit-learn 0.21 https://github.com/scikit-learn/scikit-learn/pull/12983. Particularly, I think the conflicting change is that one: https://github.com/scikit-learn/scikit-learn/pull/12983/files#diff-2229647ab9a84dc25ab3d3d13800cb43R1654