### PR TITLE
Allow for Nans in input of Permutation Importance

### DIFF
--- a/eli5/sklearn/permutation_importance.py
+++ b/eli5/sklearn/permutation_importance.py
@@ -196,7 +196,7 @@ class PermutationImportance(BaseEstimator, MetaEstimatorMixin):
             self.estimator_ = clone(self.estimator)
             self.estimator_.fit(X, y, **fit_params)
 
-        X = check_array(X, force_all_finite=False)
+        X = check_array(X, force_all_finite='allow-nan')
 
         if self.cv not in (None, "prefit"):
             si = self._cv_scores_importances(X, y, groups=groups, **fit_params)

--- a/eli5/sklearn/permutation_importance.py
+++ b/eli5/sklearn/permutation_importance.py
@@ -196,7 +196,7 @@ class PermutationImportance(BaseEstimator, MetaEstimatorMixin):
             self.estimator_ = clone(self.estimator)
             self.estimator_.fit(X, y, **fit_params)
 
-        X = check_array(X)
+        X = check_array(X, force_all_finite=False)
 
         if self.cv not in (None, "prefit"):
             si = self._cv_scores_importances(X, y, groups=groups, **fit_params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.9.0
 scipy
 singledispatch >= 3.4.0.3
-scikit-learn >= 0.18
+scikit-learn >= 0.20
 attrs > 16.0.0
 jinja2
 pip >= 8.1

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'numpy >= 1.9.0',
         'scipy',
         'six',
-        'scikit-learn >= 0.18',
+        'scikit-learn >= 0.20',
         'graphviz',
         'tabulate>=0.7.7',
     ],

--- a/tests/test_sklearn_permutation_importance.py
+++ b/tests/test_sklearn_permutation_importance.py
@@ -190,3 +190,13 @@ def test_cv_sample_weight(iris_train):
 
     # passing a vector of weights filled with one should be the same as passing no weights
     assert (perm.feature_importances_ == perm_weights.feature_importances_).all()
+
+def test_allow_nans(iris_train):
+    xgboost = pytest.importorskip('xgboost')
+
+    X, y, feature_names, target_names = iris_train
+    X[0, 0] = np.nan
+
+    perm = PermutationImportance(xgboost.XGBClassifier(), cv=5)
+    # There should be not error thrown during fitting of the model
+    perm.fit(X, y)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 ; https://github.com/Microsoft/LightGBM/tree/master/python-package#lightgbm-python-package.
 
 [tox]
-envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py36-legacy,py37-nodeps
+envlist = py27,py34,py35,py35-nodeps,mypy,py35-extra,py27-extra,py36,py36-extra,py37-nodeps
 
 [base]
 deps=


### PR DESCRIPTION
Closes #262 

So far i used  `force_all_finite=False`, but even better would be  force_all_finite='allow-nan'. But for that I would also need to increase sklearn version in the requirements to at least 0.20.