### PR TITLE
Fixed depreciated inspect function

### DIFF
--- a/eli5/base_utils.py
+++ b/eli5/base_utils.py
@@ -25,7 +25,7 @@ def attrs(class_):
         if method in class_.__dict__:
             # Allow to redefine a special method (or else attr.s will do it)
             attrs_kwargs[kw_name] = False
-    init_args = inspect.getargspec(class_.__init__)
+    init_args = inspect.getfullargspec(class_.__init__)
     defaults_shift = len(init_args.args) - len(init_args.defaults or []) - 1
     these = {}
     for idx, arg in enumerate(init_args.args[1:]):


### PR DESCRIPTION
`getfullargspec` is a drop in replacement for `getargspec`, see [docs](https://docs.python.org/3/library/inspect.html#inspect.getargspec) for details