### PR TITLE
Update to new sklearn API

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,5 @@ sphinx_rtd_theme
 ipython
 scipy
 numpy > 1.9.0
-scikit-learn >= 0.18
+scikit-learn >= 0.20
 typing

--- a/eli5/sklearn/permutation_importance.py
+++ b/eli5/sklearn/permutation_importance.py
@@ -12,7 +12,7 @@ from sklearn.base import (
     clone,
     is_classifier
 )
-from sklearn.metrics.scorer import check_scoring
+from sklearn.metrics import check_scoring
 
 from eli5.permutation_importance import get_score_importances
 from eli5.sklearn.utils import pandas_available

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.9.0
 scipy
 singledispatch >= 3.4.0.3
-scikit-learn >= 0.18
+scikit-learn >= 0.20
 attrs > 16.0.0
 jinja2
 pip >= 8.1

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'numpy >= 1.9.0',
         'scipy',
         'six',
-        'scikit-learn >= 0.18',
+        'scikit-learn >= 0.20',
         'graphviz',
         'tabulate>=0.7.7',
     ],


### PR DESCRIPTION
Change as per FutureWarning in sklearn, to allow eli5 to be used with sklearn 0.24 and newer. [docs](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.check_scoring.html)

Currently issues FutureWarning
```
  File "/app/model/model.py", line 3, in <module>
    import eli5
  File "/usr/local/lib/python3.7/site-packages/eli5/__init__.py", line 13, in <module>
    from .sklearn import explain_weights_sklearn, explain_prediction_sklearn
  File "/usr/local/lib/python3.7/site-packages/eli5/sklearn/__init__.py", line 3, in <module>
    from .explain_weights import (
  File "/usr/local/lib/python3.7/site-packages/eli5/sklearn/explain_weights.py", line 78, in <module>
    from .permutation_importance import PermutationImportance
  File "/usr/local/lib/python3.7/site-packages/eli5/sklearn/permutation_importance.py", line 15, in <module>
    from sklearn.metrics.scorer import check_scoring  # type: ignore
  File "/usr/local/lib/python3.7/site-packages/sklearn/metrics/scorer.py", line 12, in <module>
    _raise_dep_warning_if_not_pytest(deprecated_path, correct_import_path)
  File "/usr/local/lib/python3.7/site-packages/sklearn/utils/deprecation.py", line 143, in _raise_dep_warning_if_not_pytest
    warnings.warn(message, FutureWarning)
FutureWarning: The sklearn.metrics.scorer module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.metrics. Anything that cannot be imported from sklearn.metrics is now part of the private API.
```