### PR TITLE
Add support for latest xgboost version

### DIFF
--- a/eli5/xgboost.py
+++ b/eli5/xgboost.py
@@ -327,8 +327,9 @@ def _xgb_n_targets(xgb):
 
 def _xgb_feature_importances(booster, importance_type):
     fs = booster.get_score(importance_type=importance_type)
+    feature_names = booster.feature_names or ["f{0}".format(i) for i in range(booster.num_features())]
     all_features = np.array(
-        [fs.get(f, 0.) for f in booster.feature_names], dtype=np.float32)
+        [fs.get(f, 0.) for f in feature_names], dtype=np.float32)
     return all_features / all_features.sum()
 
 


### PR DESCRIPTION
eli5 fails when booster.feature_names is `None`, which is now the default behavior in xgboost when passing in a vanilla numpy array.
```python
TypeError: 'NoneType' object is not iterable
```
See https://github.com/dmlc/xgboost/commit/9da2287ab8536e4fc35e3c6664af4597353fd257 for the relevant commit in xgboost


