### PR TITLE
Added support for Jinja2 3.1.2 and scikit-learn 1.0.2

### DIFF
--- a/eli5/formatters/html.py
+++ b/eli5/formatters/html.py
@@ -18,10 +18,13 @@ from .features import FormattedFeatureName
 from .trees import tree2text
 from .text_helpers import prepare_weighted_spans, PreparedWeightedSpans
 
-
-template_env = Environment(
-    loader=PackageLoader('eli5', 'templates'),
-    extensions=['jinja2.ext.with_'])
+try:
+    template_env = Environment(
+            loader=PackageLoader('eli5', 'templates'),
+            extensions=['jinja2.ext.with_'])
+except AttributeError:
+    template_env = Environment(
+        loader=PackageLoader('eli5', 'templates'))
 template_env.globals.update(dict(zip=zip, numpy=np))
 template_env.filters.update(dict(
     weight_color=lambda w, w_range: format_hsl(weight_color_hsl(w, w_range)),
@@ -104,7 +107,7 @@ def format_as_html(explanation,  # type: Explanation
             abs(fw.weight) for fw in explanation.feature_importances.importances)
         if explanation.feature_importances else 0,
         target_weight_range=max_or_0(
-            get_weight_range(t.feature_weights) for t in targets 
+            get_weight_range(t.feature_weights) for t in targets
         if t.feature_weights is not None),
         other_weight_range=max_or_0(
             get_weight_range(other)

--- a/eli5/sklearn/permutation_importance.py
+++ b/eli5/sklearn/permutation_importance.py
@@ -12,7 +12,10 @@ from sklearn.base import (
     clone,
     is_classifier
 )
-from sklearn.metrics.scorer import check_scoring
+try:
+    from sklearn.metrics.scorer import check_scoring
+except ModuleNotFoundError:
+    from sklearn.metrics import check_scoring
 
 from eli5.permutation_importance import get_score_importances
 from eli5.sklearn.utils import pandas_available

--- a/eli5/sklearn/transform.py
+++ b/eli5/sklearn/transform.py
@@ -3,7 +3,10 @@
 
 import numpy as np
 from sklearn.pipeline import Pipeline, FeatureUnion
-from sklearn.feature_selection.base import SelectorMixin
+try:
+    from sklearn.feature_selection.base import SelectorMixin
+except ModuleNotFoundError:
+    from sklearn.feature_selection import SelectorMixin
 
 from sklearn.preprocessing import (
     MinMaxScaler,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,15 @@
+import jinja2
+import sklearn
+
+
+def test_import():
+	from packaging import version
+	if version.parse(jinja2.__version__) <= version.parse('3.0.3'):
+		raise ImportError('module "Jinja2" must be of a later version than "3.0.3".')
+	if version.parse(sklearn.__version__) < version.parse('1.0.2'):
+		raise ImportError('module "Jinja2" must be version "1.0.2" or later.')
+	import eli5
+
+
+if __name__ == '__main__':
+	test_import()


### PR DESCRIPTION
When using Jinja2 3.1.2 and scikit-learn 1.0.2, the following errors occurred:
- AttributeError: module 'jinja2.ext' has no attribute 'with_'
- ModuleNotFoundError: No module named 'sklearn.metrics.scorer'
- ModuleNotFoundError: No module named 'sklearn.feature_selection.base'

The changes in 'html.py', 'permutation_importance.py' and 'transform.py' are such that these errors are resolved while maintaining support for older versions of jinja2 and scikit-learn.

'test_import.py' is used to test importing eli5 for both newer and older dependency versions.

Also see: https://github.com/TeamHG-Memex/eli5/issues/417